### PR TITLE
change so we are dealing in seconds for tokens

### DIFF
--- a/config/server.json
+++ b/config/server.json
@@ -14,7 +14,7 @@
     "apiSecret": "This is a local API secret for everyone. BsscSHqSHiwrBMJsEGqbvXiuIUPAjQXU",
     "longTermKey": "abcdefghijklmnopqrstuvwxyz",
     "longTermDaysDuration": 30,
-    "tokenHoursDuration": 720,
+    "tokenDurationSecs": 2592000,
     "salt" : "ADihSEI7tOQQP9xfXMO9HfRpXKu1NpIJ",
     "verificationSecret" : "+skip"
   },

--- a/user/api_test.go
+++ b/user/api_test.go
@@ -30,7 +30,7 @@ var (
 	FAKE_CONFIG = ApiConfig{
 		ServerSecret:       "shhh! don't tell",
 		Secret:             "shhh! don't tell *2",
-		TokenHoursDuration: 8,
+		TokenDurationSecs:  3600,
 		LongTermKey:        "the longetermkey",
 		Salt:               "a mineral substance composed primarily of sodium chloride",
 		VerificationSecret: "",
@@ -40,9 +40,9 @@ var (
 	 */
 	USR           = &User{Id: "123-99-100", Name: "Test One", Emails: []string{"test@new.bar"}}
 	usrTknData    = &TokenData{UserId: USR.Id, IsServer: false, DurationSecs: 3600}
-	USR_TOKEN, _  = CreateSessionToken(usrTknData, TokenConfig{DurationHours: FAKE_CONFIG.TokenHoursDuration, Secret: FAKE_CONFIG.Secret})
+	USR_TOKEN, _  = CreateSessionToken(usrTknData, TokenConfig{DurationSecs: FAKE_CONFIG.TokenDurationSecs, Secret: FAKE_CONFIG.Secret})
 	sverTknData   = &TokenData{UserId: "shoreline", IsServer: true, DurationSecs: 36000}
-	SRVR_TOKEN, _ = CreateSessionToken(sverTknData, TokenConfig{DurationHours: FAKE_CONFIG.TokenHoursDuration, Secret: FAKE_CONFIG.Secret})
+	SRVR_TOKEN, _ = CreateSessionToken(sverTknData, TokenConfig{DurationSecs: FAKE_CONFIG.TokenDurationSecs, Secret: FAKE_CONFIG.Secret})
 	/*
 	 * basics setup
 	 */
@@ -75,7 +75,7 @@ func TestGetStatus_StatusOk(t *testing.T) {
 	shoreline.GetStatus(response, request)
 
 	if response.Code != http.StatusOK {
-		t.Fatalf("Resp given [%s] expected [%s] ", response.Code, http.StatusOK)
+		t.Fatalf("Resp given [%d] expected [%d] ", response.Code, http.StatusOK)
 	}
 
 }
@@ -90,7 +90,7 @@ func TestGetStatus_StatusInternalServerError(t *testing.T) {
 	shorelineFails.GetStatus(response, request)
 
 	if response.Code != http.StatusInternalServerError {
-		t.Fatalf("Resp given [%s] expected [%s] ", response.Code, http.StatusInternalServerError)
+		t.Fatalf("Resp given [%d] expected [%d] ", response.Code, http.StatusInternalServerError)
 	}
 
 	body, _ := ioutil.ReadAll(response.Body)

--- a/user/helpers.go
+++ b/user/helpers.go
@@ -125,7 +125,7 @@ func (a *Api) addUserAndSendStatus(user *User, res http.ResponseWriter, req *htt
 	}
 	if sessionToken, err := CreateSessionTokenAndSave(
 		&TokenData{DurationSecs: extractTokenDuration(req), UserId: user.Id, IsServer: false},
-		TokenConfig{DurationHours: a.ApiConfig.TokenHoursDuration, Secret: a.ApiConfig.Secret},
+		TokenConfig{DurationSecs: a.ApiConfig.TokenDurationSecs, Secret: a.ApiConfig.Secret},
 		a.Store); err != nil {
 		log.Printf(USER_API_PREFIX+"addUserAndSendStatus %s err[%s]", STATUS_ERR_GENERATING_TOKEN, err.Error())
 		sendModelAsResWithStatus(res, status.NewStatus(http.StatusInternalServerError, STATUS_ERR_GENERATING_TOKEN), http.StatusInternalServerError)

--- a/user/mongoStoreClient_test.go
+++ b/user/mongoStoreClient_test.go
@@ -154,8 +154,7 @@ func TestMongoStoreUserOperations(t *testing.T) {
 func TestMongoStoreTokenOperations(t *testing.T) {
 
 	testing_token_data := &TokenData{UserId: "2341", IsServer: true, DurationSecs: 3600}
-	testing_fake_secret := "some secret for the tests"
-	testing_token_hrs_duration := 12
+	testing_token_config := TokenConfig{DurationSecs: 1200, Secret: "some secret for the tests"}
 	testingConfig := &mongo.Config{ConnectionString: "mongodb://localhost/user_test"}
 
 	mc := NewMongoStoreClient(testingConfig)
@@ -179,7 +178,7 @@ func TestMongoStoreTokenOperations(t *testing.T) {
 	 */
 	sessionToken, _ := CreateSessionToken(
 		testing_token_data,
-		TokenConfig{DurationHours: testing_token_hrs_duration, Secret: testing_fake_secret},
+		testing_token_config,
 	)
 
 	if err := mc.AddToken(sessionToken); err != nil {

--- a/user/token.go
+++ b/user/token.go
@@ -24,8 +24,8 @@ type (
 	}
 
 	TokenConfig struct {
-		Secret        string
-		DurationHours int
+		Secret       string
+		DurationSecs float64
 	}
 )
 
@@ -42,7 +42,7 @@ func CreateSessionToken(data *TokenData, config TokenConfig) (token *SessionToke
 	}
 
 	if data.DurationSecs == 0 {
-		data.DurationSecs = (time.Hour * time.Duration(config.DurationHours)).Seconds() //As per configuartion
+		data.DurationSecs = config.DurationSecs //As per configuartion
 		if data.IsServer {
 			data.DurationSecs = (time.Hour * 24).Seconds() //24 hours
 		}

--- a/user/token_test.go
+++ b/user/token_test.go
@@ -13,8 +13,8 @@ type tokenTestData struct {
 }
 
 var tokenConfig = TokenConfig{
-	DurationHours: 24,
-	Secret:        "my secret",
+	DurationSecs: 3600,
+	Secret:       "my secret",
 }
 
 func Test_GetSessionToken(t *testing.T) {
@@ -65,7 +65,7 @@ func Test_GenerateSessionToken_DurationFromConfig(t *testing.T) {
 
 	td := token.unpackToken(tokenConfig.Secret)
 
-	if td.DurationSecs != time.Duration(time.Hour*time.Duration(tokenConfig.DurationHours)).Seconds() {
+	if td.DurationSecs != tokenConfig.DurationSecs {
 		t.Fatalf("the duration should be from config")
 	}
 }


### PR DESCRIPTION
so unlike the branch name I have switched the code to configure based on seconds. This matches the units that tokens use and also allows us easier testing, as we can expire the token very quickly 

@darinkrauss  