### PR TITLE
Add emailVerified to user response from API

### DIFF
--- a/user/api_test.go
+++ b/user/api_test.go
@@ -1475,8 +1475,6 @@ func TestManageIdHashPair_StatusCreated_WhenPut(t *testing.T) {
 
 func TestAnonIdHashPair_InBulk(t *testing.T) {
 
-	req, _ := http.NewRequest("GET", "/", nil)
-	res := httptest.NewRecorder()
 	shoreline.SetHandlers("", rtr)
 
 	// we ask for 100 AnonymousIdHashPair to be created
@@ -1484,16 +1482,21 @@ func TestAnonIdHashPair_InBulk(t *testing.T) {
 	ask := make([]AnonIdHashPair, 100)
 	var generated []AnonIdHashPair
 
+	var mutex sync.Mutex 
 	var wg sync.WaitGroup
 
 	for _, hash := range ask {
 		wg.Add(1)
 		go func(hash AnonIdHashPair) {
 			defer wg.Done()
+			req, _ := http.NewRequest("GET", "/", nil)
+			res := httptest.NewRecorder()
 			shoreline.AnonymousIdHashPair(res, req)
 			body, _ := ioutil.ReadAll(res.Body)
 			json.Unmarshal(body, &hash)
+			mutex.Lock()
 			generated = append(generated, hash)
+			mutex.Unlock()
 		}(hash)
 
 	}

--- a/user/api_test.go
+++ b/user/api_test.go
@@ -161,6 +161,16 @@ func TestCreateUser_StatusCreated(t *testing.T) {
 		t.Fatal("body should have the userid")
 	}
 
+	var boolData map[string]bool
+	_ = json.Unmarshal(body, &boolData)
+
+	if boolData == nil {
+		t.Fatal("body should have been returned")
+	}
+
+	if emailVerified, ok := boolData["emailVerified"]; !ok || emailVerified {
+		t.Fatal("body should have emailVerified set to false")
+	}
 }
 
 func TestCreateChildUser_StatusCreated(t *testing.T) {
@@ -201,6 +211,16 @@ func TestCreateChildUser_StatusCreated(t *testing.T) {
 		t.Fatal("body should have the userid")
 	}
 
+	var boolData map[string]bool
+	_ = json.Unmarshal(body, &boolData)
+
+	if boolData == nil {
+		t.Fatal("body should have been returned")
+	}
+
+	if emailVerified, ok := boolData["emailVerified"]; !ok || !emailVerified {
+		t.Fatal("body should have emailVerified set to true")
+	}
 }
 
 func TestCreateUser_Failure(t *testing.T) {
@@ -662,6 +682,20 @@ func TestLogin_StatusOK(t *testing.T) {
 
 	if response.Header().Get("content-type") != "application/json" {
 		t.Fatal("the resp should be json")
+	}
+
+
+	body, _ := ioutil.ReadAll(response.Body)
+
+	var boolData map[string]bool
+	_ = json.Unmarshal(body, &boolData)
+
+	if boolData == nil {
+		t.Fatal("body should have been returned")
+	}
+
+	if emailVerified, ok := boolData["emailVerified"]; !ok || !emailVerified {
+		t.Fatal("body should have emailVerified set to true")
 	}
 }
 

--- a/user/user.go
+++ b/user/user.go
@@ -13,7 +13,7 @@ type User struct {
 	Name          string                 `json:"username" bson:"username"`
 	Emails        []string               `json:"emails" bson:"emails"`
 	TermsAccepted string                 `json:"termsAccepted" bson:"termsAccepted"`
-	Verified      bool                   `json:"-" bson:"authenticated"` //tag is name `authenticated` for historical reasons
+	Verified      bool                   `json:"emailVerified" bson:"authenticated"` //tag is name `authenticated` for historical reasons
 	PwHash        string                 `json:"-" bson:"pwhash"`
 	Hash          string                 `json:"-" bson:"userhash"`
 	Private       map[string]*IdHashPair `json:"-" bson:"private"`


### PR DESCRIPTION
@jh-bate @jebeck Jana requested the emailVerified flag so Blip can more easily detect when the email address is not verified. Added test for emailVerified. Fix a broken test with concurrency issues.