### PR TITLE
Add user roles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ dist
 .idea
 *.iml
 shoreline
+user-roles

--- a/Comedeps
+++ b/Comedeps
@@ -4,4 +4,5 @@ github.com/gorilla/mux git https://github.com/gorilla/mux.git 14cafe28513321476c
 github.com/gorilla/context git https://github.com/gorilla/context.git 14f550f51af52180c2eefed15e5fd18d63c0a64a
 github.com/dgrijalva/jwt-go git https://github.com/dgrijalva/jwt-go.git v1.0.1
 github.com/RangelReale/osin git https://github.com/RangelReale/osin.git 9f043d7e6be414ff4c71af39d2cfffc10ccc7ea4
-github.com/tidepool-org/go-common git https://github.com/tidepool-org/go-common.git a74c284b9989616e6ef60a9123c487ec88e0e3e4
+github.com/tidepool-org/go-common git https://github.com/tidepool-org/go-common.git cc69b1bf2402bdb80ecdc4dfda044df702876786
+github.com/codegangsta/cli git https://github.com/codegangsta/cli cf1f63a7274872768d4037305d572b70b1199397

--- a/build
+++ b/build
@@ -11,5 +11,6 @@ rm -rf ${OUTDIR}
 mkdir ${OUTDIR}
 
 go build -o ${OUTDIR}/${PROJECT}
+go build -o ${OUTDIR}/user-roles tools/user-roles.go
 
 cp start.sh ${OUTDIR}/

--- a/oauth2/api.go
+++ b/oauth2/api.go
@@ -309,7 +309,7 @@ func (o *Api) signup(w http.ResponseWriter, r *http.Request) {
 				Id:          signupResp.UserID,
 				Secret:      secret,
 				RedirectUri: r.Form.Get("uri"),
-				UserData:    map[string]interface{}{"AppName": signupResp.UserName},
+				UserData:    map[string]interface{}{"AppName": signupResp.Username},
 			}
 
 			authData := &osin.AuthorizeData{

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,32 @@
+## Add role to a user
+
+```
+$ user-roles add --env local --email foo@bar.org --role clinic
+```
+
+## Remove role from a user
+
+```
+$ user-roles remove --env local --email foo@bar.org --role clinic
+```
+
+## Find users by role
+
+```
+$ user-roles find --env local --role clinic
+```
+
+### Roles
+
+The `role` parameter can be one of:
+
+`clinic`
+
+### Environments
+
+The `env` parameter can be one of:
+
+`prd`
+`stg`
+`dev`
+`local`

--- a/tools/user-roles.go
+++ b/tools/user-roles.go
@@ -1,0 +1,398 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+
+	"github.com/codegangsta/cli"
+	"github.com/tidepool-org/go-common/clients/shoreline"
+)
+
+const (
+	TidepoolServerName   = "x-tidepool-server-name"
+	TidepoolServerSecret = "x-tidepool-server-secret"
+	TidepoolSessionToken = "x-tidepool-session-token"
+)
+
+type admin struct {
+	client *http.Client
+	secret string
+	host   string
+	token  string
+}
+
+func main() {
+	app := cli.NewApp()
+	app.Name = "User Roles"
+	app.Usage = "Manage user roles"
+	app.Version = "0.0.1"
+	app.Author = "Jamie"
+	app.Email = "jamie@tidepool.org"
+
+	const environmentUsage = "Target environment (one of: \"prd\", \"stg\", \"dev\", \"local\")"
+
+	app.Commands = []cli.Command{
+		{
+			Name:      "find",
+			ShortName: "f",
+			Usage:     "Find all users assigned a role",
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:  "role",
+					Usage: "Role to search for (one of: \"clinic\")",
+				},
+				cli.StringFlag{
+					Name:  "env",
+					Usage: environmentUsage,
+				},
+			},
+			Action: findUsersWithRole,
+		},
+		{
+			Name:      "add",
+			ShortName: "a",
+			Usage:     `Add the specified role to an existing user found by email`,
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:  "email",
+					Usage: "Email address for the user",
+				},
+				cli.StringFlag{
+					Name:  "role",
+					Usage: "Role to add to the user (one of: \"clinic\")",
+				},
+				cli.StringFlag{
+					Name:  "env",
+					Usage: environmentUsage,
+				},
+			},
+			Action: addRoleToUser,
+		},
+		{
+			Name:      "remove",
+			ShortName: "r",
+			Usage:     "Remove the specified role from an existing user found by email",
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:  "email",
+					Usage: "Email address for the user",
+				},
+				cli.StringFlag{
+					Name:  "role",
+					Usage: "Role to remove from the user (one of: \"clinic\")",
+				},
+				cli.StringFlag{
+					Name:  "env",
+					Usage: environmentUsage,
+				},
+			},
+			Action: removeRoleFromUser,
+		},
+	}
+
+	app.Run(os.Args)
+}
+
+func die(err error) {
+	fmt.Println("ERROR:", err)
+	os.Exit(1)
+}
+
+func findUsersWithRole(c *cli.Context) {
+	if a, err := NewAdmin(c.String("env")); err != nil {
+		die(err)
+	} else if users, err := a.GetUsersWithRole(c.String("role")); err != nil {
+		die(err)
+	} else {
+		for _, user := range users {
+			dumpUser(&user)
+		}
+	}
+}
+
+func addRoleToUser(c *cli.Context) {
+	if updater, err := NewAddUserRoleUpdater(c.String("role")); err != nil {
+		die(err)
+	} else {
+		applyUpdatesToUser(c, []UserUpdater{updater})
+	}
+}
+
+func removeRoleFromUser(c *cli.Context) {
+	if updater, err := NewRemoveUserRoleUpdater(c.String("role")); err != nil {
+		die(err)
+	} else {
+		applyUpdatesToUser(c, []UserUpdater{updater})
+	}
+}
+
+func applyUpdatesToUser(c *cli.Context, updaters []UserUpdater) {
+	if a, err := NewAdmin(c.String("env")); err != nil {
+		die(err)
+	} else if user, err := a.GetUserByEmail(c.String("email")); err != nil {
+		die(err)
+	} else if user, err := a.ApplyUpdatesToUser(user, updaters); err != nil {
+		die(err)
+	} else {
+		dumpUser(user)
+	}
+}
+
+type UserUpdater interface {
+	Update(user *shoreline.UserData, updates *shoreline.UserUpdate) error
+}
+
+type AddUserRoleUpdater struct {
+	role string
+}
+
+func NewAddUserRoleUpdater(role string) (*AddUserRoleUpdater, error) {
+	if role == "" {
+		return nil, errors.New("Role not specified")
+	} else {
+		return &AddUserRoleUpdater{role: role}, nil
+	}
+}
+
+func (m *AddUserRoleUpdater) Update(user *shoreline.UserData, updates *shoreline.UserUpdate) error {
+	var originalRoles *[]string
+	if updates.Roles != nil {
+		originalRoles = updates.Roles
+	} else if user.Roles != nil {
+		originalRoles = &user.Roles
+	} else {
+		originalRoles = &[]string{}
+	}
+
+	for _, role := range *originalRoles {
+		if role == m.role {
+			return nil
+		}
+	}
+
+	updatedRoles := append(*originalRoles, m.role)
+	updates.Roles = &updatedRoles
+	return nil
+}
+
+type RemoveUserRoleUpdater struct {
+	role string
+}
+
+func NewRemoveUserRoleUpdater(role string) (*RemoveUserRoleUpdater, error) {
+	if role == "" {
+		return nil, errors.New("Role not specified")
+	} else {
+		return &RemoveUserRoleUpdater{role: role}, nil
+	}
+}
+
+func (m *RemoveUserRoleUpdater) Update(user *shoreline.UserData, updates *shoreline.UserUpdate) error {
+	var originalRoles *[]string
+	if updates.Roles != nil {
+		originalRoles = updates.Roles
+	} else if user.Roles != nil {
+		originalRoles = &user.Roles
+	} else {
+		return nil
+	}
+
+	updatedRoles := make([]string, 0)
+	for _, role := range *originalRoles {
+		if role != m.role {
+			updatedRoles = append(updatedRoles, role)
+		}
+	}
+
+	updates.Roles = &updatedRoles
+	return nil
+}
+
+func NewAdmin(env string) (*admin, error) {
+	if secret := os.Getenv("SERVER_SECRET"); secret == "" {
+		return nil, errors.New("Environment variable SERVER_SECRET not specified")
+	} else if host, err := envToHost(env); err != nil {
+		return nil, err
+	} else {
+		return &admin{secret: secret, client: &http.Client{}, host: host}, nil
+	}
+}
+
+func (a *admin) LoginAsServer() error {
+	if a.token != "" {
+		return nil
+	}
+
+	req, err := http.NewRequest("POST", a.urlWithHost("/auth/serverlogin"), nil)
+	if err != nil {
+		return errors.New(fmt.Sprintf("Error creating new server login request: %s", err.Error()))
+	}
+
+	req.Header.Add(TidepoolServerName, "USER_ROLES")
+	req.Header.Add(TidepoolServerSecret, a.secret)
+
+	res, err := a.client.Do(req)
+	if err != nil {
+		return errors.New(fmt.Sprintf("Error sending server login request: %s", err.Error()))
+	} else if res.StatusCode != http.StatusOK {
+		body := &bytes.Buffer{}
+		body.ReadFrom(res.Body)
+		return errors.New(fmt.Sprintf("Unexpected response status code from server login request: [%d] %s", res.StatusCode, body))
+	}
+
+	a.token = res.Header.Get(TidepoolSessionToken)
+	if a.token == "" {
+		return errors.New("No session token returned from server login request")
+	}
+	return nil
+}
+
+func (a *admin) GetUserByEmail(email string) (*shoreline.UserData, error) {
+	if email == "" {
+		return nil, errors.New("Email not specified")
+	}
+
+	if err := a.LoginAsServer(); err != nil {
+		return nil, err
+	}
+
+	url := fmt.Sprintf("/auth/user/%s", email)
+	req, err := http.NewRequest("GET", a.urlWithHost(url), nil)
+	if err != nil {
+		return nil, errors.New(fmt.Sprintf("Error creating new get user request: %s", err.Error()))
+	}
+
+	req.Header.Add(TidepoolSessionToken, a.token)
+
+	res, err := a.client.Do(req)
+	if err != nil {
+		return nil, errors.New(fmt.Sprintf("Error sending get user request: %s", err.Error()))
+	} else if res.StatusCode != http.StatusOK {
+		body := &bytes.Buffer{}
+		body.ReadFrom(res.Body)
+		return nil, errors.New(fmt.Sprintf("Unexpected response status code from get user request: [%d] %s", res.StatusCode, body))
+	}
+
+	var user shoreline.UserData
+	if err := json.NewDecoder(res.Body).Decode(&user); err != nil {
+		return nil, errors.New(fmt.Sprintf("Error decoding JSON from get user request: %s", err.Error()))
+	}
+	return &user, nil
+}
+
+func (a *admin) GetUsersWithRole(role string) ([]shoreline.UserData, error) {
+	if role == "" {
+		return nil, errors.New("Role not specified")
+	}
+
+	if err := a.LoginAsServer(); err != nil {
+		return nil, err
+	}
+
+	url := fmt.Sprintf("/auth/users?role=%s", url.QueryEscape(role))
+	req, err := http.NewRequest("GET", a.urlWithHost(url), nil)
+	if err != nil {
+		return nil, errors.New(fmt.Sprintf("Error creating new get users request: %s", err.Error()))
+	}
+
+	req.Header.Add(TidepoolSessionToken, a.token)
+
+	res, err := a.client.Do(req)
+	if err != nil {
+		return nil, errors.New(fmt.Sprintf("Error sending get users request: %s", err.Error()))
+	} else if res.StatusCode != http.StatusOK {
+		body := &bytes.Buffer{}
+		body.ReadFrom(res.Body)
+		return nil, errors.New(fmt.Sprintf("Unexpected response status code from get users request: [%d] %s", res.StatusCode, body))
+	}
+
+	var users []shoreline.UserData
+	if err := json.NewDecoder(res.Body).Decode(&users); err != nil {
+		return nil, errors.New(fmt.Sprintf("Error decoding JSON from get users request: %s", err.Error()))
+	}
+	return users, nil
+}
+
+func (a *admin) ApplyUpdatesToUser(user *shoreline.UserData, updaters []UserUpdater) (*shoreline.UserData, error) {
+	if user == nil {
+		return nil, errors.New("User not specified")
+	}
+
+	if err := a.LoginAsServer(); err != nil {
+		return nil, err
+	}
+
+	updates := shoreline.UserUpdate{}
+	for _, updater := range updaters {
+		if err := updater.Update(user, &updates); err != nil {
+			return nil, errors.New(fmt.Sprintf("Error updating user: %s", err.Error()))
+		}
+	}
+
+	if !updates.HasUpdates() {
+		return user, nil
+	}
+
+	requestBody := &bytes.Buffer{}
+	updateRequest := &map[string]shoreline.UserUpdate{"updates": updates}
+	if err := json.NewEncoder(requestBody).Encode(updateRequest); err != nil {
+		return nil, errors.New(fmt.Sprintf("Error encoding JSON for update user request: %s", err.Error()))
+	}
+
+	url := fmt.Sprintf("/auth/user/%s", user.UserID)
+	req, err := http.NewRequest("PUT", a.urlWithHost(url), requestBody)
+	if err != nil {
+		return nil, errors.New(fmt.Sprintf("Error creating new update user request: %s", err.Error()))
+	}
+
+	req.Header.Add(TidepoolSessionToken, a.token)
+
+	res, err := a.client.Do(req)
+	if err != nil {
+		return nil, errors.New(fmt.Sprintf("Error sending update user request: %s", err.Error()))
+	} else if res.StatusCode != http.StatusOK {
+		body := &bytes.Buffer{}
+		body.ReadFrom(res.Body)
+		return nil, errors.New(fmt.Sprintf("Unexpected response status code from update user request: [%d] %s", res.StatusCode, body))
+	}
+
+	if err := json.NewDecoder(res.Body).Decode(user); err != nil {
+		return nil, errors.New(fmt.Sprintf("Error decoding JSON from update user request: %s", err.Error()))
+	}
+
+	return user, nil
+}
+
+func (a *admin) urlWithHost(path string) string {
+	return fmt.Sprintf("%s%s", a.host, path)
+}
+
+func envToHost(env string) (string, error) {
+	switch env {
+	case "prd":
+		return "https://api.tidepool.org", nil
+	case "stg":
+		return "https://stg-api.tidepool.org", nil
+	case "dev":
+		return "https://dev-api.tidepool.org", nil
+	case "local":
+		return "http://localhost:8009", nil
+	case "":
+		return "", errors.New("Environment not specified")
+	default:
+		return "", errors.New(fmt.Sprintf("Invalid environment: %s", env))
+	}
+}
+
+func dumpUser(user *shoreline.UserData) {
+	if dump, err := json.Marshal(user); err != nil {
+		fmt.Printf("Error dumping user: %s\n", err.Error())
+	} else {
+		fmt.Printf("%s\n", dump)
+	}
+}

--- a/user/apiClient.go
+++ b/user/apiClient.go
@@ -134,6 +134,6 @@ func (client *UserClient) GetUser(userID, token string) (*commonUserApi.UserData
 }
 
 // FIXME: Not required for OAUTH API, but still...
-func (client *UserClient) UpdateUser(user commonUserApi.UserUpdate, token string) error {
+func (client *UserClient) UpdateUser(userID string, userUpdate commonUserApi.UserUpdate, token string) error {
 	return nil
 }

--- a/user/helpers.go
+++ b/user/helpers.go
@@ -50,7 +50,6 @@ func unpackAuth(authLine string) (usr *User, pw string) {
 
 func sendModelAsRes(res http.ResponseWriter, model interface{}) {
 	sendModelAsResWithStatus(res, model, http.StatusOK)
-	return
 }
 
 func sendModelAsResWithStatus(res http.ResponseWriter, model interface{}, statusCode int) {
@@ -62,7 +61,6 @@ func sendModelAsResWithStatus(res http.ResponseWriter, model interface{}, status
 	} else {
 		res.Write(jsonDetails)
 	}
-	return
 }
 
 //send metric
@@ -109,6 +107,16 @@ func (a *Api) sendUserWithStatus(res http.ResponseWriter, user *User, statusCode
 	sendModelAsResWithStatus(res, a.asSerializableUser(user, isServerRequest), statusCode)
 }
 
+func (a *Api) sendUsers(res http.ResponseWriter, users []*User, isServerRequest bool) {
+	serializables := make([]interface{}, len(users))
+	if users != nil {
+		for index, user := range users {
+			serializables[index] = a.asSerializableUser(user, isServerRequest)
+		}
+	}
+	sendModelAsRes(res, serializables)
+}
+
 func (a *Api) asSerializableUser(user *User, isServerRequest bool) interface{} {
 	serializable := make(map[string]interface{})
 	if len(user.Id) > 0 {
@@ -119,6 +127,9 @@ func (a *Api) asSerializableUser(user *User, isServerRequest bool) interface{} {
 	}
 	if len(user.Emails) > 0 {
 		serializable["emails"] = user.Emails
+	}
+	if len(user.Roles) > 0 {
+		serializable["roles"] = user.Roles
 	}
 	if len(user.TermsAccepted) > 0 {
 		serializable["termsAccepted"] = user.TermsAccepted

--- a/user/helpers_test.go
+++ b/user/helpers_test.go
@@ -67,6 +67,14 @@ func Test_AsSerializableUser_Emails(t *testing.T) {
 	}
 }
 
+func Test_AsSerializableUser_Roles(t *testing.T) {
+	user := &User{Roles: []string{"clinic"}}
+	serializableUser := shoreline.asSerializableUser(user, false).(map[string]interface{})
+	if len(serializableUser) != 1 || !reflect.DeepEqual(serializableUser["roles"], user.Roles) {
+		t.Fatalf("Serializable user [%#v] does not match User [%#v] for roles", serializableUser, user)
+	}
+}
+
 func Test_AsSerializableUser_TermsAccepted(t *testing.T) {
 	user := &User{TermsAccepted: "2016-01-01T00:00:00-08:00"}
 	serializableUser := shoreline.asSerializableUser(user, false).(map[string]interface{})

--- a/user/mongoStoreClient.go
+++ b/user/mongoStoreClient.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"regexp"
+	"sort"
 
 	"github.com/tidepool-org/go-common/clients/mongo"
 	"labix.org/v2/mgo"
@@ -59,6 +60,10 @@ func (d MongoStoreClient) UpsertUser(user *User) error {
 	cpy := d.session.Copy()
 	defer cpy.Close()
 
+	if user.Roles != nil {
+		sort.Strings(user.Roles)
+	}
+
 	// if the user already exists we update otherwise we add
 	if _, err := mgoUsersCollection(cpy).Upsert(bson.M{"userid": user.Id}, user); err != nil {
 		return err
@@ -96,6 +101,9 @@ func (d MongoStoreClient) FindUsers(user *User) (results []*User, err error) {
 	}
 	if len(user.Emails) > 0 {
 		fieldsToMatch = append(fieldsToMatch, bson.M{"emails": bson.M{"$in": user.Emails}})
+	}
+	if len(user.Roles) > 0 {
+		fieldsToMatch = append(fieldsToMatch, bson.M{"roles": bson.M{"$in": user.Roles}})
 	}
 
 	if len(fieldsToMatch) == 0 {

--- a/user/user_test.go
+++ b/user/user_test.go
@@ -144,6 +144,24 @@ func Test_IsValidEmail_Valid(t *testing.T) {
 	}
 }
 
+func Test_IsValidRole_Invalid(t *testing.T) {
+	invalidRoles := []string{"", "abcdefg"}
+	for _, invalidRole := range invalidRoles {
+		if IsValidRole(invalidRole) {
+			t.Fatalf("Invalid role %s is unexpectedly valid", invalidRole)
+		}
+	}
+}
+
+func Test_IsValidRole_Valid(t *testing.T) {
+	validRoles := []string{"clinic"}
+	for _, validRole := range validRoles {
+		if !IsValidRole(validRole) {
+			t.Fatalf("Valid role %s is unexpectedly invalid", validRole)
+		}
+	}
+}
+
 func Test_IsValidPassword_Invalid(t *testing.T) {
 	invalidPasswords := []string{"", "1", "1234567", "123  678", "1234567890123456789012345678901234  789012345678901234567890123456789012", "1234567890123456789012345678901234567890123456789012345678901234567890123"}
 	for _, invalidPassword := range invalidPasswords {
@@ -699,7 +717,7 @@ func Test_UpdateUserDetails_ExtractFromJSON_InvalidJSON(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Unexpected success for invalid JSON")
 	}
-	if details.Username != nil || details.Emails != nil || details.Password != nil || details.TermsAccepted != nil || details.EmailVerified != nil {
+	if details.Username != nil || details.Emails != nil || details.Password != nil || details.Roles != nil || details.TermsAccepted != nil || details.EmailVerified != nil {
 		t.Fatalf("Unexpected fields present on error for invalid JSON")
 	}
 }
@@ -711,79 +729,91 @@ func Test_UpdateUserDetails_ExtractFromJSON_MissingUpdates(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Unexpected success for invalid JSON")
 	}
-	if details.Username != nil || details.Emails != nil || details.Password != nil || details.TermsAccepted != nil || details.EmailVerified != nil {
+	if details.Username != nil || details.Emails != nil || details.Password != nil || details.Roles != nil || details.TermsAccepted != nil || details.EmailVerified != nil {
 		t.Fatalf("Unexpected fields present on error for invalid JSON")
 	}
 }
 
 func Test_UpdateUserDetails_ExtractFromJSON_InvalidUsername(t *testing.T) {
-	source := "{\"updates\": {\"username\": true, \"emails\": [\"b@y.com\"], \"password\": \"12345678\", \"termsAccepted\": \"2016-01-01T12:00:00-08:00\", \"emailVerified\": true}}"
+	source := "{\"updates\": {\"username\": true, \"emails\": [\"b@y.com\"], \"password\": \"12345678\", \"roles\": [\"clinic\"], \"termsAccepted\": \"2016-01-01T12:00:00-08:00\", \"emailVerified\": true}}"
 	details := &UpdateUserDetails{}
 	err := details.ExtractFromJSON(strings.NewReader(source))
 	if err != User_error_username_invalid {
 		t.Fatalf("Unexpected error for invalid username: %#v", err)
 	}
-	if details.Username != nil || details.Emails != nil || details.Password != nil || details.TermsAccepted != nil || details.EmailVerified != nil {
+	if details.Username != nil || details.Emails != nil || details.Password != nil || details.Roles != nil || details.TermsAccepted != nil || details.EmailVerified != nil {
 		t.Fatalf("Unexpected fields present on error for invalid username")
 	}
 }
 
 func Test_UpdateUserDetails_ExtractFromJSON_InvalidEmails(t *testing.T) {
-	source := "{\"updates\": {\"username\": \"a@z.co\", \"emails\": true, \"password\": \"12345678\", \"termsAccepted\": \"2016-01-01T12:00:00-08:00\", \"emailVerified\": true}}"
+	source := "{\"updates\": {\"username\": \"a@z.co\", \"emails\": true, \"password\": \"12345678\", \"roles\": [\"clinic\"], \"termsAccepted\": \"2016-01-01T12:00:00-08:00\", \"emailVerified\": true}}"
 	details := &UpdateUserDetails{}
 	err := details.ExtractFromJSON(strings.NewReader(source))
 	if err != User_error_emails_invalid {
 		t.Fatalf("Unexpected error for invalid emails: %#v", err)
 	}
-	if details.Username != nil || details.Emails != nil || details.Password != nil || details.TermsAccepted != nil || details.EmailVerified != nil {
+	if details.Username != nil || details.Emails != nil || details.Password != nil || details.Roles != nil || details.TermsAccepted != nil || details.EmailVerified != nil {
 		t.Fatalf("Unexpected fields present on error for invalid emails")
 	}
 }
 
 func Test_UpdateUserDetails_ExtractFromJSON_InvalidPassword(t *testing.T) {
-	source := "{\"updates\": {\"username\": \"a@z.co\", \"emails\": [\"b@y.co\"], \"password\": true, \"termsAccepted\": \"2016-01-01T12:00:00-08:00\", \"emailVerified\": true}}"
+	source := "{\"updates\": {\"username\": \"a@z.co\", \"emails\": [\"b@y.co\"], \"password\": true, \"roles\": [\"clinic\"], \"termsAccepted\": \"2016-01-01T12:00:00-08:00\", \"emailVerified\": true}}"
 	details := &UpdateUserDetails{}
 	err := details.ExtractFromJSON(strings.NewReader(source))
 	if err != User_error_password_invalid {
 		t.Fatalf("Unexpected error for invalid password: %#v", err)
 	}
-	if details.Username != nil || details.Emails != nil || details.Password != nil || details.TermsAccepted != nil || details.EmailVerified != nil {
+	if details.Username != nil || details.Emails != nil || details.Password != nil || details.Roles != nil || details.TermsAccepted != nil || details.EmailVerified != nil {
 		t.Fatalf("Unexpected fields present on error for invalid password")
 	}
 }
 
+func Test_UpdateUserDetails_ExtractFromJSON_InvalidRoles(t *testing.T) {
+	source := "{\"updates\": {\"username\": \"a@z.co\", \"emails\": [\"b@y.co\"], \"password\": \"12345678\", \"roles\": [true], \"termsAccepted\": \"2016-01-01T12:00:00-08:00\", \"emailVerified\": true}}"
+	details := &UpdateUserDetails{}
+	err := details.ExtractFromJSON(strings.NewReader(source))
+	if err != User_error_roles_invalid {
+		t.Fatalf("Unexpected error for invalid roles: %#v", err)
+	}
+	if details.Username != nil || details.Emails != nil || details.Password != nil || details.Roles != nil || details.TermsAccepted != nil || details.EmailVerified != nil {
+		t.Fatalf("Unexpected fields present on error for invalid roles")
+	}
+}
+
 func Test_UpdateUserDetails_ExtractFromJSON_InvalidTermsAccepted(t *testing.T) {
-	source := "{\"updates\": {\"username\": \"a@z.co\", \"emails\": [\"b@y.co\"], \"password\": \"12345678\", \"termsAccepted\": true, \"emailVerified\": true}}"
+	source := "{\"updates\": {\"username\": \"a@z.co\", \"emails\": [\"b@y.co\"], \"password\": \"12345678\", \"roles\": [\"clinic\"], \"termsAccepted\": true, \"emailVerified\": true}}"
 	details := &UpdateUserDetails{}
 	err := details.ExtractFromJSON(strings.NewReader(source))
 	if err != User_error_terms_accepted_invalid {
 		t.Fatalf("Unexpected error for invalid password: %#v", err)
 	}
-	if details.Username != nil || details.Emails != nil || details.Password != nil || details.TermsAccepted != nil || details.EmailVerified != nil {
+	if details.Username != nil || details.Emails != nil || details.Password != nil || details.Roles != nil || details.TermsAccepted != nil || details.EmailVerified != nil {
 		t.Fatalf("Unexpected fields present on error for invalid password")
 	}
 }
 
 func Test_UpdateUserDetails_ExtractFromJSON_InvalidEmailVerified(t *testing.T) {
-	source := "{\"updates\": {\"username\": \"a@z.co\", \"emails\": [\"b@y.co\"], \"password\": \"12345678\", \"termsAccepted\": \"2016-01-01T12:00:00-08:00\", \"emailVerified\": \"unexpected\"}}"
+	source := "{\"updates\": {\"username\": \"a@z.co\", \"emails\": [\"b@y.co\"], \"password\": \"12345678\", \"roles\": [\"clinic\"], \"termsAccepted\": \"2016-01-01T12:00:00-08:00\", \"emailVerified\": \"unexpected\"}}"
 	details := &UpdateUserDetails{}
 	err := details.ExtractFromJSON(strings.NewReader(source))
 	if err != User_error_email_verified_invalid {
 		t.Fatalf("Unexpected error for invalid password: %#v", err)
 	}
-	if details.Username != nil || details.Emails != nil || details.Password != nil || details.TermsAccepted != nil || details.EmailVerified != nil {
+	if details.Username != nil || details.Emails != nil || details.Password != nil || details.Roles != nil || details.TermsAccepted != nil || details.EmailVerified != nil {
 		t.Fatalf("Unexpected fields present on error for invalid password")
 	}
 }
 
 func Test_UpdateUserDetails_ExtractFromJSON_ValidAll(t *testing.T) {
-	source := "{\"updates\": {\"username\": \"a@z.co\", \"emails\": [\"b@y.co\"], \"password\": \"12345678\", \"termsAccepted\": \"2016-01-01T12:00:00-08:00\", \"emailVerified\": true, \"ignored\": true}}"
+	source := "{\"updates\": {\"username\": \"a@z.co\", \"emails\": [\"b@y.co\"], \"password\": \"12345678\", \"roles\": [\"clinic\"], \"termsAccepted\": \"2016-01-01T12:00:00-08:00\", \"emailVerified\": true, \"ignored\": true}}"
 	details := &UpdateUserDetails{}
 	err := details.ExtractFromJSON(strings.NewReader(source))
 	if err != nil {
 		t.Fatalf("Unexpected error for valid with all: %#v", err)
 	}
-	if *details.Username != "a@z.co" || !reflect.DeepEqual(details.Emails, []string{"b@y.co"}) || *details.Password != "12345678" || *details.TermsAccepted != "2016-01-01T12:00:00-08:00" || !*details.EmailVerified {
+	if *details.Username != "a@z.co" || !reflect.DeepEqual(details.Emails, []string{"b@y.co"}) || *details.Password != "12345678" || !reflect.DeepEqual(details.Roles, []string{"clinic"}) || *details.TermsAccepted != "2016-01-01T12:00:00-08:00" || !*details.EmailVerified {
 		t.Fatalf("Missing fields that should be present on success with all")
 	}
 }
@@ -795,7 +825,7 @@ func Test_UpdateUserDetails_ExtractFromJSON_ValidUsername(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error for valid with username: %#v", err)
 	}
-	if *details.Username != "a@z.co" || details.Emails != nil || details.Password != nil || details.TermsAccepted != nil || details.EmailVerified != nil {
+	if *details.Username != "a@z.co" || details.Emails != nil || details.Password != nil || details.Roles != nil || details.TermsAccepted != nil || details.EmailVerified != nil {
 		t.Fatalf("Missing fields that should be present on success with username")
 	}
 }
@@ -807,7 +837,7 @@ func Test_UpdateUserDetails_ExtractFromJSON_ValidEmails(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error for valid with emails: %#v", err)
 	}
-	if details.Username != nil || !reflect.DeepEqual(details.Emails, []string{"b@y.co"}) || details.Password != nil || details.TermsAccepted != nil || details.EmailVerified != nil {
+	if details.Username != nil || !reflect.DeepEqual(details.Emails, []string{"b@y.co"}) || details.Password != nil || details.Roles != nil || details.TermsAccepted != nil || details.EmailVerified != nil {
 		t.Fatalf("Missing fields that should be present on success with emails")
 	}
 }
@@ -819,8 +849,20 @@ func Test_UpdateUserDetails_ExtractFromJSON_ValidPassword(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error for valid with password: %#v", err)
 	}
-	if details.Username != nil || details.Emails != nil || *details.Password != "12345678" || details.TermsAccepted != nil || details.EmailVerified != nil {
+	if details.Username != nil || details.Emails != nil || *details.Password != "12345678" || details.Roles != nil || details.TermsAccepted != nil || details.EmailVerified != nil {
 		t.Fatalf("Missing fields that should be present on success with password")
+	}
+}
+
+func Test_UpdateUserDetails_ExtractFromJSON_ValidRoles(t *testing.T) {
+	source := "{\"updates\": {\"roles\": [\"clinic\"], \"ignored\": true}}"
+	details := &UpdateUserDetails{}
+	err := details.ExtractFromJSON(strings.NewReader(source))
+	if err != nil {
+		t.Fatalf("Unexpected error for valid with roles: %#v", err)
+	}
+	if details.Username != nil || details.Emails != nil || details.Password != nil || !reflect.DeepEqual(details.Roles, []string{"clinic"}) || details.TermsAccepted != nil || details.EmailVerified != nil {
+		t.Fatalf("Missing fields that should be present on success with roles")
 	}
 }
 
@@ -831,7 +873,7 @@ func Test_UpdateUserDetails_ExtractFromJSON_ValidTermsAccepted(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error for valid with password: %#v", err)
 	}
-	if details.Username != nil || details.Emails != nil || details.Password != nil || *details.TermsAccepted != "2016-01-01T12:00:00-08:00" || details.EmailVerified != nil {
+	if details.Username != nil || details.Emails != nil || details.Password != nil || details.Roles != nil || *details.TermsAccepted != "2016-01-01T12:00:00-08:00" || details.EmailVerified != nil {
 		t.Fatalf("Missing fields that should be present on success with password")
 	}
 }
@@ -843,7 +885,7 @@ func Test_UpdateUserDetails_ExtractFromJSON_ValidEmailVerified(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error for valid with password: %#v", err)
 	}
-	if details.Username != nil || details.Emails != nil || details.Password != nil || details.TermsAccepted != nil || !*details.EmailVerified {
+	if details.Username != nil || details.Emails != nil || details.Password != nil || details.Roles != nil || details.TermsAccepted != nil || !*details.EmailVerified {
 		t.Fatalf("Missing fields that should be present on success with password")
 	}
 }
@@ -852,7 +894,7 @@ func Test_UpdateUserDetails_Validate_Username_Missing(t *testing.T) {
 	password := "12345678"
 	termsAccepted := "2016-01-01T12:00:00-08:00"
 	emailVerified := true
-	details := &UpdateUserDetails{Emails: []string{"b@y.co", "c@x.co"}, Password: &password, TermsAccepted: &termsAccepted, EmailVerified: &emailVerified}
+	details := &UpdateUserDetails{Emails: []string{"b@y.co", "c@x.co"}, Password: &password, Roles: []string{"clinic"}, TermsAccepted: &termsAccepted, EmailVerified: &emailVerified}
 	err := details.Validate()
 	if err != nil {
 		t.Fatalf("Unexpected error for username missing: %#v", err)
@@ -864,7 +906,7 @@ func Test_UpdateUserDetails_Validate_Username_Invalid(t *testing.T) {
 	password := "12345678"
 	termsAccepted := "2016-01-01T12:00:00-08:00"
 	emailVerified := true
-	details := &UpdateUserDetails{Username: &username, Emails: []string{"b@y.co", "c@x.co"}, Password: &password, TermsAccepted: &termsAccepted, EmailVerified: &emailVerified}
+	details := &UpdateUserDetails{Username: &username, Emails: []string{"b@y.co", "c@x.co"}, Password: &password, Roles: []string{"clinic"}, TermsAccepted: &termsAccepted, EmailVerified: &emailVerified}
 	err := details.Validate()
 	if err != User_error_username_invalid {
 		t.Fatalf("Unexpected error for username invalid: %#v", err)
@@ -876,7 +918,7 @@ func Test_UpdateUserDetails_Validate_Emails_Missing(t *testing.T) {
 	password := "12345678"
 	termsAccepted := "2016-01-01T12:00:00-08:00"
 	emailVerified := true
-	details := &UpdateUserDetails{Username: &username, Password: &password, TermsAccepted: &termsAccepted, EmailVerified: &emailVerified}
+	details := &UpdateUserDetails{Username: &username, Password: &password, Roles: []string{"clinic"}, TermsAccepted: &termsAccepted, EmailVerified: &emailVerified}
 	err := details.Validate()
 	if err != nil {
 		t.Fatalf("Unexpected error for emails missing: %#v", err)
@@ -888,7 +930,7 @@ func Test_UpdateUserDetails_Validate_Emails_Invalid(t *testing.T) {
 	password := "12345678"
 	termsAccepted := "2016-01-01T12:00:00-08:00"
 	emailVerified := true
-	details := &UpdateUserDetails{Username: &username, Emails: []string{"b@y.co", "c"}, Password: &password, TermsAccepted: &termsAccepted, EmailVerified: &emailVerified}
+	details := &UpdateUserDetails{Username: &username, Emails: []string{"b@y.co", "c"}, Password: &password, Roles: []string{"clinic"}, TermsAccepted: &termsAccepted, EmailVerified: &emailVerified}
 	err := details.Validate()
 	if err != User_error_emails_invalid {
 		t.Fatalf("Unexpected error for emails invalid: %#v", err)
@@ -899,7 +941,7 @@ func Test_UpdateUserDetails_Validate_Password_Missing(t *testing.T) {
 	username := "a@z.co"
 	termsAccepted := "2016-01-01T12:00:00-08:00"
 	emailVerified := true
-	details := &UpdateUserDetails{Username: &username, Emails: []string{"b@y.co", "c@x.co"}, TermsAccepted: &termsAccepted, EmailVerified: &emailVerified}
+	details := &UpdateUserDetails{Username: &username, Emails: []string{"b@y.co", "c@x.co"}, Roles: []string{"clinic"}, TermsAccepted: &termsAccepted, EmailVerified: &emailVerified}
 	err := details.Validate()
 	if err != nil {
 		t.Fatalf("Unexpected error for password missing: %#v", err)
@@ -911,10 +953,34 @@ func Test_UpdateUserDetails_Validate_Password_Invalid(t *testing.T) {
 	password := "1234567"
 	termsAccepted := "2016-01-01T12:00:00-08:00"
 	emailVerified := true
-	details := &UpdateUserDetails{Username: &username, Emails: []string{"b@y.co", "c@x.co"}, Password: &password, TermsAccepted: &termsAccepted, EmailVerified: &emailVerified}
+	details := &UpdateUserDetails{Username: &username, Emails: []string{"b@y.co", "c@x.co"}, Password: &password, Roles: []string{"clinic"}, TermsAccepted: &termsAccepted, EmailVerified: &emailVerified}
 	err := details.Validate()
 	if err != User_error_password_invalid {
 		t.Fatalf("Unexpected error for password invalid: %#v", err)
+	}
+}
+
+func Test_UpdateUserDetails_Validate_Roles_Missing(t *testing.T) {
+	username := "a@z.co"
+	password := "12345678"
+	termsAccepted := "2016-01-01T12:00:00-08:00"
+	emailVerified := true
+	details := &UpdateUserDetails{Username: &username, Password: &password, TermsAccepted: &termsAccepted, EmailVerified: &emailVerified}
+	err := details.Validate()
+	if err != nil {
+		t.Fatalf("Unexpected error for roles missing: %#v", err)
+	}
+}
+
+func Test_UpdateUserDetails_Validate_Roles_Invalid(t *testing.T) {
+	username := "a@z.co"
+	password := "12345678"
+	termsAccepted := "2016-01-01T12:00:00-08:00"
+	emailVerified := true
+	details := &UpdateUserDetails{Username: &username, Emails: []string{"b@y.co", "c"}, Password: &password, Roles: []string{"invalid"}, TermsAccepted: &termsAccepted, EmailVerified: &emailVerified}
+	err := details.Validate()
+	if err != User_error_emails_invalid {
+		t.Fatalf("Unexpected error for roles invalid: %#v", err)
 	}
 }
 
@@ -922,7 +988,7 @@ func Test_UpdateUserDetails_Validate_TermsAccepted_Missing(t *testing.T) {
 	username := "a@z.co"
 	password := "12345678"
 	emailVerified := true
-	details := &UpdateUserDetails{Username: &username, Emails: []string{"b@y.co", "c@x.co"}, Password: &password, EmailVerified: &emailVerified}
+	details := &UpdateUserDetails{Username: &username, Emails: []string{"b@y.co", "c@x.co"}, Password: &password, Roles: []string{"clinic"}, EmailVerified: &emailVerified}
 	err := details.Validate()
 	if err != nil {
 		t.Fatalf("Unexpected error for password missing: %#v", err)
@@ -934,7 +1000,7 @@ func Test_UpdateUserDetails_Validate_TermsAccepted_Invalid(t *testing.T) {
 	password := "12345678"
 	termsAccepted := "2016-13-32T24:65:65-24:30"
 	emailVerified := true
-	details := &UpdateUserDetails{Username: &username, Emails: []string{"b@y.co", "c@x.co"}, Password: &password, TermsAccepted: &termsAccepted, EmailVerified: &emailVerified}
+	details := &UpdateUserDetails{Username: &username, Emails: []string{"b@y.co", "c@x.co"}, Password: &password, Roles: []string{"clinic"}, TermsAccepted: &termsAccepted, EmailVerified: &emailVerified}
 	err := details.Validate()
 	if err != User_error_terms_accepted_invalid {
 		t.Fatalf("Unexpected error for password invalid: %#v", err)
@@ -945,7 +1011,7 @@ func Test_UpdateUserDetails_Validate_EmailVerified_Missing(t *testing.T) {
 	username := "a@z.co"
 	password := "12345678"
 	termsAccepted := "2016-01-01T12:00:00-08:00"
-	details := &UpdateUserDetails{Username: &username, Emails: []string{"b@y.co", "c@x.co"}, Password: &password, TermsAccepted: &termsAccepted}
+	details := &UpdateUserDetails{Username: &username, Emails: []string{"b@y.co", "c@x.co"}, Password: &password, Roles: []string{"clinic"}, TermsAccepted: &termsAccepted}
 	err := details.Validate()
 	if err != nil {
 		t.Fatalf("Unexpected error for password missing: %#v", err)
@@ -957,7 +1023,7 @@ func Test_UpdateUserDetails_Validate_Valid(t *testing.T) {
 	password := "12345678"
 	termsAccepted := "2016-01-01T12:00:00-08:00"
 	emailVerified := true
-	details := &UpdateUserDetails{Username: &username, Emails: []string{"b@y.co", "c@x.co"}, Password: &password, TermsAccepted: &termsAccepted, EmailVerified: &emailVerified}
+	details := &UpdateUserDetails{Username: &username, Emails: []string{"b@y.co", "c@x.co"}, Password: &password, Roles: []string{"clinic"}, TermsAccepted: &termsAccepted, EmailVerified: &emailVerified}
 	err := details.Validate()
 	if err != nil {
 		t.Fatalf("Unexpected error for valid: %#v", err)
@@ -976,7 +1042,7 @@ func Test_ParseUpdateUserDetails_InvalidJSON(t *testing.T) {
 }
 
 func Test_ParseUpdateUserDetails_ValidAll(t *testing.T) {
-	source := "{\"updates\": {\"username\": \"a@z.co\", \"emails\": [\"b@y.co\"], \"password\": \"12345678\", \"termsAccepted\": \"2016-01-01T12:00:00-08:00\", \"emailVerified\": true}}"
+	source := "{\"updates\": {\"username\": \"a@z.co\", \"emails\": [\"b@y.co\"], \"password\": \"12345678\", \"roles\": [\"clinic\"], \"termsAccepted\": \"2016-01-01T12:00:00-08:00\", \"emailVerified\": true}}"
 	details, err := ParseUpdateUserDetails(strings.NewReader(source))
 	if err != nil {
 		t.Fatalf("Unexpected error for valid with all: %#v", err)
@@ -1108,6 +1174,7 @@ func Test_User_DeepClone(t *testing.T) {
 		Id:            "1234567890",
 		Username:      "a@b.co",
 		Emails:        []string{"a@b.co", "c@d.co"},
+		Roles:         []string{"clinic"},
 		TermsAccepted: "2016-01-01T12:34:56-08:00",
 		EmailVerified: true,
 		PwHash:        "this-is-the-password-hash",


### PR DESCRIPTION
- Manual merge due to significant conflicting changes
- Use latest go-common; related updates
- Use github.com/codegangsta/cli for user-roles command line tool
- Command line tool for finding users with role and adding/removing roles
- Add roles to user API, interfaces, and structs
- New GetUsers API to find users by role (server only)
- UpdateUser can accept updates to roles (server only)
- New and updated tests
- Sort roles before adding to database

*Note: This PR is only for the clinic role work and replaces the sprint26-clinic-accounts branch and https://github.com/tidepool-org/shoreline/pull/29 PR.

@jh-bate 