### PR TITLE
add to the README for user-roles tool so that a front-ender has enough info to work with

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -1,3 +1,10 @@
+As long as you've been building shoreline as part of using Tidepool's [runservers](https://github.com/tidepool-org/tools/blob/master/runservers) to run the entire platform locally, you should have the binary for this tool in a `dist/` directory at the root of this repository.
+
+If you're not using runservers, please see the instructions in [the general README](../README.md) for how to build shoreline in isolation.
+
+To use the `user-roles` binary, you must have the shoreline service running with config variables set in the environment. In other words, if you're using runservers, just run the following commands in the Terminal window/tab where you started the runservers (the commands will look more like e.g., `shoreline/dist/user-roles find --env local --role clinic` than what follows, where the full path has been omitted for concision).
+
+
 ## Add role to a user
 
 ```


### PR DESCRIPTION
I needed help to use the `user-roles` tool locally to create a VCA locally, so I've expanded the README a bit. Review for accuracy @darinkrauss or @jh-bate?