### PR TITLE
Additional database fields for SessionToken; minor logic updates

### DIFF
--- a/user/mockStoreClient.go
+++ b/user/mockStoreClient.go
@@ -103,17 +103,17 @@ func (d MockStoreClient) AddToken(token *SessionToken) error {
 	return nil
 }
 
-func (d MockStoreClient) FindToken(token *SessionToken) (*SessionToken, error) {
+func (d MockStoreClient) FindTokenByID(id string) (*SessionToken, error) {
 	if d.doBad {
-		return nil, errors.New("FindToken failure")
+		return nil, errors.New("FindTokenByID failure")
 	}
 	//`find` a pretend one we just made
-	return token, nil
+	return nil, nil
 }
 
-func (d MockStoreClient) RemoveToken(token *SessionToken) error {
+func (d MockStoreClient) RemoveTokenByID(id string) error {
 	if d.doBad {
-		return errors.New("RemoveToken failure")
+		return errors.New("RemoveTokenByID failure")
 	}
 	return nil
 }

--- a/user/mongoStoreClient.go
+++ b/user/mongoStoreClient.go
@@ -136,39 +136,35 @@ func (d MongoStoreClient) RemoveUser(user *User) (err error) {
 }
 
 func (d MongoStoreClient) AddToken(st *SessionToken) error {
-	//map to the structure we want to save to mongo as
-	token := bson.M{"_id": st.Id, "time": st.Time}
 	cpy := d.session.Copy()
 	defer cpy.Close()
 
-	if _, err := mgoTokensCollection(cpy).Upsert(bson.M{"_id": st.Id}, token); err != nil {
+	if _, err := mgoTokensCollection(cpy).Upsert(bson.M{"_id": st.ID}, st); err != nil {
 		return err
 	}
+
 	return nil
 }
 
-func (d MongoStoreClient) FindToken(st *SessionToken) (*SessionToken, error) {
-
-	var result map[string]interface{}
+func (d MongoStoreClient) FindTokenByID(id string) (*SessionToken, error) {
 	cpy := d.session.Copy()
 	defer cpy.Close()
 
-	if err := mgoTokensCollection(cpy).Find(bson.M{"_id": st.Id}).One(&result); err != nil {
+	sessionToken := &SessionToken{}
+	if err := mgoTokensCollection(cpy).Find(bson.M{"_id": id}).One(&sessionToken); err != nil {
 		return nil, err
 	}
-	//map to the token structure the service uses
-	tkn := &SessionToken{Id: result["_id"].(string), Time: result["time"].(int64)}
 
-	return tkn, nil
+	return sessionToken, nil
 }
 
-func (d MongoStoreClient) RemoveToken(st *SessionToken) (err error) {
-
+func (d MongoStoreClient) RemoveTokenByID(id string) (err error) {
 	cpy := d.session.Copy()
 	defer cpy.Close()
 
-	if err = mgoTokensCollection(cpy).Remove(bson.M{"_id": st.Id}); err != nil {
+	if err = mgoTokensCollection(cpy).Remove(bson.M{"_id": id}); err != nil {
 		return err
 	}
+
 	return nil
 }

--- a/user/mongoStoreClient_test.go
+++ b/user/mongoStoreClient_test.go
@@ -229,8 +229,8 @@ func TestMongoStoreTokenOperations(t *testing.T) {
 		t.Fatalf("we could not save the token %v", err)
 	}
 
-	if foundToken, err := mc.FindToken(sessionToken); err == nil {
-		if foundToken.Id == "" {
+	if foundToken, err := mc.FindTokenByID(sessionToken.ID); err == nil {
+		if foundToken.ID == "" {
 			t.Fatalf("the token string isn't included %v", foundToken)
 		}
 		if foundToken.Time == 0 {
@@ -240,11 +240,11 @@ func TestMongoStoreTokenOperations(t *testing.T) {
 		t.Fatalf("no token was returned when it should have been - err[%v]", err)
 	}
 
-	if err := mc.RemoveToken(sessionToken); err != nil {
+	if err := mc.RemoveTokenByID(sessionToken.ID); err != nil {
 		t.Fatalf("we could not remove the token %v", err)
 	}
 
-	if token, err := mc.FindToken(sessionToken); err == nil {
+	if token, err := mc.FindTokenByID(sessionToken.ID); err == nil {
 		if token != nil {
 			t.Fatalf("the token has been removed so we shouldn't find it %v", token)
 		}

--- a/user/responsableMockStoreClient.go
+++ b/user/responsableMockStoreClient.go
@@ -10,20 +10,20 @@ type FindUserResponse struct {
 	Error error
 }
 
-type FindTokenResponse struct {
+type FindTokenByIDResponse struct {
 	SessionToken *SessionToken
 	Error        error
 }
 
 type ResponsableMockStoreClient struct {
-	PingResponses        []error
-	UpsertUserResponses  []error
-	FindUsersResponses   []FindUsersResponse
-	FindUserResponses    []FindUserResponse
-	RemoveUserResponses  []error
-	AddTokenResponses    []error
-	FindTokenResponses   []FindTokenResponse
-	RemoveTokenResponses []error
+	PingResponses            []error
+	UpsertUserResponses      []error
+	FindUsersResponses       []FindUsersResponse
+	FindUserResponses        []FindUserResponse
+	RemoveUserResponses      []error
+	AddTokenResponses        []error
+	FindTokenByIDResponses   []FindTokenByIDResponse
+	RemoveTokenByIDResponses []error
 }
 
 func NewResponsableMockStoreClient() *ResponsableMockStoreClient {
@@ -37,8 +37,8 @@ func (r *ResponsableMockStoreClient) HasResponses() bool {
 		len(r.FindUserResponses) > 0 ||
 		len(r.RemoveUserResponses) > 0 ||
 		len(r.AddTokenResponses) > 0 ||
-		len(r.FindTokenResponses) > 0 ||
-		len(r.RemoveTokenResponses) > 0
+		len(r.FindTokenByIDResponses) > 0 ||
+		len(r.RemoveTokenByIDResponses) > 0
 }
 
 func (r *ResponsableMockStoreClient) Reset() {
@@ -48,8 +48,8 @@ func (r *ResponsableMockStoreClient) Reset() {
 	r.FindUserResponses = nil
 	r.RemoveUserResponses = nil
 	r.AddTokenResponses = nil
-	r.FindTokenResponses = nil
-	r.RemoveTokenResponses = nil
+	r.FindTokenByIDResponses = nil
+	r.RemoveTokenByIDResponses = nil
 }
 
 func (r *ResponsableMockStoreClient) Close() {
@@ -105,19 +105,19 @@ func (r *ResponsableMockStoreClient) AddToken(token *SessionToken) (err error) {
 	panic("AddTokenResponses unavailable")
 }
 
-func (r *ResponsableMockStoreClient) FindToken(token *SessionToken) (*SessionToken, error) {
-	if len(r.FindTokenResponses) > 0 {
-		var response FindTokenResponse
-		response, r.FindTokenResponses = r.FindTokenResponses[0], r.FindTokenResponses[1:]
+func (r *ResponsableMockStoreClient) FindTokenByID(id string) (*SessionToken, error) {
+	if len(r.FindTokenByIDResponses) > 0 {
+		var response FindTokenByIDResponse
+		response, r.FindTokenByIDResponses = r.FindTokenByIDResponses[0], r.FindTokenByIDResponses[1:]
 		return response.SessionToken, response.Error
 	}
-	panic("FindTokenResponses unavailable")
+	panic("FindTokenByIDResponses unavailable")
 }
 
-func (r *ResponsableMockStoreClient) RemoveToken(token *SessionToken) (err error) {
-	if len(r.RemoveTokenResponses) > 0 {
-		err, r.RemoveTokenResponses = r.RemoveTokenResponses[0], r.RemoveTokenResponses[1:]
+func (r *ResponsableMockStoreClient) RemoveTokenByID(id string) (err error) {
+	if len(r.RemoveTokenByIDResponses) > 0 {
+		err, r.RemoveTokenByIDResponses = r.RemoveTokenByIDResponses[0], r.RemoveTokenByIDResponses[1:]
 		return err
 	}
-	panic("RemoveTokenResponses unavailable")
+	panic("RemoveTokenByIDResponses unavailable")
 }

--- a/user/storage.go
+++ b/user/storage.go
@@ -8,6 +8,6 @@ type Storage interface {
 	FindUsers(user *User) ([]*User, error)
 	RemoveUser(user *User) error
 	AddToken(token *SessionToken) error
-	FindToken(token *SessionToken) (*SessionToken, error)
-	RemoveToken(token *SessionToken) error
+	FindTokenByID(id string) (*SessionToken, error)
+	RemoveTokenByID(id string) error
 }


### PR DESCRIPTION
@jh-bate Required for delete user work. Push more token related info into database (so they can be deleted when a user is deleted). SessionToken struct matches that in `platform` repo. Use `int64` or duration (rather that `float64`) as it is more accurate representation (and eliminates some issues). Find and Remove SessionToken by ID (not partially constructed SessionToken struct). Simplify unpacking SessionToken ID logic and difference between SessionToken and TokenData. (Eventually TokenData should be removed in favor of just SessionToken.)

Most of the changes are simple renames, but `token.go` and `mongoStoreClient.go` have the important bits.