### PR TITLE
we log this but do nothing with it

### DIFF
--- a/user/api.go
+++ b/user/api.go
@@ -610,13 +610,6 @@ func (a *Api) RefreshSession(res http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	const two_hours_in_secs = 60 * 60 * 2
-
-	if td.IsServer == false && td.DurationSecs > two_hours_in_secs {
-		//long-duration let us know detail and keep it rolling
-		a.logger.Println("long-duration token set for ", fmt.Sprint(time.Duration(td.DurationSecs)*time.Second))
-	}
-	//refresh
 	if sessionToken, err := CreateSessionTokenAndSave(
 		td,
 		TokenConfig{DurationSecs: a.ApiConfig.TokenDurationSecs, Secret: a.ApiConfig.Secret},


### PR DESCRIPTION
@darinkrauss going through the server logs to find an actual issue and 99% of the logs are full of this. I don't see the need 

```
api/user 2017/12/18 13:04:50 api.go:616: long-duration token set for  720h0m0s
api/user 2017/12/18 13:05:04 api.go:616: long-duration token set for  720h0m0s
api/user 2017/12/18 13:06:25 api.go:616: long-duration token set for  720h0m0s
api/user 2017/12/18 13:07:19 api.go:616: long-duration token set for  720h0m0s
api/user 2017/12/18 13:07:31 api.go:616: long-duration token set for  720h0m0s
```