### PR TITLE
Fix decoding of complex password in Authorization header

### DIFF
--- a/user/api_test.go
+++ b/user/api_test.go
@@ -16,9 +16,9 @@ import (
 	"testing"
 
 	"github.com/gorilla/mux"
-
 	"github.com/tidepool-org/go-common/clients"
 	"github.com/tidepool-org/go-common/clients/highwater"
+
 	"github.com/tidepool-org/shoreline/oauth2"
 )
 
@@ -85,7 +85,7 @@ func InitShoreline(config ApiConfig, store Storage, metrics highwater.Client, pe
 ////////////////////////////////////////////////////////////////////////////////
 
 func T_CreateAuthorization(t *testing.T, email string, password string) string {
-	return fmt.Sprintf("Basic %s", base64.URLEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", email, password))))
+	return fmt.Sprintf("Basic %s", base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", email, password))))
 }
 
 func T_CreateSessionToken(t *testing.T, userId string, isServer bool, duration int64) *SessionToken {
@@ -1281,6 +1281,23 @@ func Test_Login_Error_ErrorCreatingToken(t *testing.T) {
 func Test_Login_Success(t *testing.T) {
 	authorization := T_CreateAuthorization(t, "a@b.co", "password")
 	responsableStore.FindUsersResponses = []FindUsersResponse{{[]*User{&User{Id: "1111111111", Username: "a@z.co", Emails: []string{"a@z.co"}, TermsAccepted: "2016-01-01T01:23:45-08:00", PwHash: "d1fef52139b0d120100726bcb43d5cc13d41e4b5", EmailVerified: true}}, nil}}
+	responsableStore.AddTokenResponses = []error{nil}
+	defer T_ExpectResponsablesEmpty(t)
+
+	headers := http.Header{}
+	headers.Add("Authorization", authorization)
+	response := T_PerformRequestHeaders(t, "POST", "/login", headers)
+	successResponse := T_ExpectSuccessResponseWithJSONMap(t, response, 200)
+	T_ExpectElementMatch(t, successResponse, "userid", `\A[0-9a-f]{10}\z`, true)
+	T_ExpectEqualsMap(t, successResponse, map[string]interface{}{"emailVerified": true, "emails": []interface{}{"a@z.co"}, "username": "a@z.co", "termsAccepted": "2016-01-01T01:23:45-08:00"})
+	if response.Header().Get(TP_SESSION_TOKEN) == "" {
+		t.Fatalf("Missing expected %s header", TP_SESSION_TOKEN)
+	}
+}
+
+func Test_Login_Success_Password_Complex(t *testing.T) {
+	authorization := T_CreateAuthorization(t, "a@b.co", "`-=[]\\;',./~!@#$%^&*)(_+}{|\":<>?`¡™£¢∞§¶•ª–≠‘“æ…÷≥”’")
+	responsableStore.FindUsersResponses = []FindUsersResponse{{[]*User{&User{Id: "1111111111", Username: "a@z.co", Emails: []string{"a@z.co"}, TermsAccepted: "2016-01-01T01:23:45-08:00", PwHash: "80464ae775ca97187d29bc4b3e391e959947138a", EmailVerified: true}}, nil}}
 	responsableStore.AddTokenResponses = []error{nil}
 	defer T_ExpectResponsablesEmpty(t)
 

--- a/user/helpers.go
+++ b/user/helpers.go
@@ -35,10 +35,10 @@ func unpackAuth(authLine string) (usr *User, pw string) {
 	if authLine != "" {
 		parts := strings.SplitN(authLine, " ", 2)
 		payload := parts[1]
-		if decodedPayload, err := base64.URLEncoding.DecodeString(payload); err != nil {
+		if decodedPayload, err := base64.StdEncoding.DecodeString(payload); err != nil {
 			log.Print(USER_API_PREFIX, "Error unpacking authorization header [%s]", err.Error())
 		} else {
-			details := strings.Split(string(decodedPayload), ":")
+			details := strings.SplitN(string(decodedPayload), ":", 2)
 			if details[0] != "" || details[1] != "" {
 				//Note the incoming `name` could infact be id, email or the username
 				return &User{Id: details[0], Username: details[0], Emails: []string{details[0]}}, details[1]


### PR DESCRIPTION
@pazaan There were two issues with decoding the password from the HTTP Authorization header when calling the login API. These issues have been around since the initial implementation in early 2015. Neither issue represented a security risk, but would just return a false authentication failure (that the password was incorrect even though it was correct).

First, the entire Authorization header value was being incorrectly decoded using the URL form of Base64 encoding rather than the Standard form.  (The URL form is used only for Base64 encoded values in an actual URL itself while the Standard form is used everywhere else. The URL form uses a `-` in place of the Standard form `+`.)

Second, after decoding the Base64 encoded header, the resulting string was split by the `:` separator which delimits the username and password. Unfortunately, the split did not limit it to exactly two parts (username for the first part and everything else was the password). So, if the password contained one or more colons then the resulting split only captured the first portion of the password before the first `:`.

Both of these problems are now resolved.