### PR TITLE
Added feature flag to skip the start of the Hakken service.

### DIFF
--- a/shoreline.go
+++ b/shoreline.go
@@ -48,10 +48,14 @@ func main() {
 		WithConfig(&config.HakkenConfig).
 		Build()
 
-	if err := hakkenClient.Start(); err != nil {
-		log.Fatal(shoreline_service_prefix, err)
+	if !config.HakkenConfig.SkipHakken {
+		if err := hakkenClient.Start(); err != nil {
+			log.Fatal(shoreline_service_prefix, err)
+		}
+		defer hakkenClient.Close()
+	} else {
+		log.Print("skipping hakken service")
 	}
-	defer hakkenClient.Close()
 
 	/*
 	 * Clients

--- a/vendor/github.com/tidepool-org/go-common/clients/hakken/hakken.go
+++ b/vendor/github.com/tidepool-org/go-common/clients/hakken/hakken.go
@@ -22,6 +22,7 @@ type HakkenClientConfig struct {
 	HeartbeatInterval jepson.Duration `json:"heartbeatInterval"` // Time elapsed between heartbeats and watch polls
 	PollInterval      jepson.Duration `json:"pollInterval"`      // Time elapsed between coordinator gossip polls
 	ResyncInterval    jepson.Duration `json:"resyncInterval"`    // Time elapsed between checks for new coordinators at Host
+	SkipHakken        bool            `json:"skipHakken"`        // True is Hakken service is not used
 }
 
 type HakkenClientBuilder struct {


### PR DESCRIPTION
This change inspects a new feature flag in the Hakken Config.  If true, then shoreline will not attempt to contact hakken.

@pazaan This presumes that the go-common code has been changed as well to add the feature flag.