### PR TITLE
Encode JWTs with public key encryption. Use standard claims. BACK-1372

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,5 +14,6 @@ require (
 	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/pborman/uuid v0.0.0-20180906182336-adf5a7427709 // indirect
 	github.com/prometheus/client_golang v1.4.1
+	github.com/rs/zerolog v1.18.0
 	github.com/tidepool-org/go-common v0.5.0
 )

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,7 @@ github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/codegangsta/cli v1.20.0 h1:iX1FXEgwzd5+XN6wk5cVHOGQj6Q3Dcp20lUeS4lHNTw=
 github.com/codegangsta/cli v1.20.0/go.mod h1:/qJNoX69yVSKu5o4jLyXAENLRyk1uhi7zkbQ3slBdOA=
+github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -75,6 +76,9 @@ github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R
 github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/procfs v0.0.8 h1:+fpWZdT24pJBiqJdAwYBjPSk+5YmQzYNPYzQsdzLkt8=
 github.com/prometheus/procfs v0.0.8/go.mod h1:7Qr8sr6344vo1JqZ6HhLceV9o3AJ1Ff+GxbHq6oeK9A=
+github.com/rs/xid v1.2.1/go.mod h1:+uKXf+4Djp6Md1KODXJxgGQPKngRmWyn10oCKFzNHOQ=
+github.com/rs/zerolog v1.18.0 h1:CbAm3kP2Tptby1i9sYy2MGRg0uxIN9cyDb59Ys7W8z8=
+github.com/rs/zerolog v1.18.0/go.mod h1:9nvC1axdVrAHcu/s9taAVfBuIdTZLVQmKQyvrUjF5+I=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -84,12 +88,15 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/tidepool-org/go-common v0.5.0 h1:Atycq5m1l0P8YBRTz0NZGs8PKAx7cr8iRQzzdyRXFCo=
 github.com/tidepool-org/go-common v0.5.0/go.mod h1:tZr3DhGKfB4CbgwaeItEW7sulUXZTBUJ1vi4SVgdYxE=
+github.com/zenazn/goji v0.9.0/go.mod h1:7S9M489iMyHBNxwZnk9/EHS098H4/F6TATF2mIxtB1Q=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/net v0.0.0-20181114220301-adae6a3d119a/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190613194153-d28f0bde5980/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181116152217-5ac8a444bdc5/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -98,6 +105,8 @@ golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200122134326-e047566fdf82 h1:ywK/j/KkyTHcdyYSZNXGjMwgmDSfjglYZ3vStQ/gSCU=
 golang.org/x/sys v0.0.0-20200122134326-e047566fdf82/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/tools v0.0.0-20190828213141-aed303cbaa74/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/shoreline.go
+++ b/shoreline.go
@@ -79,12 +79,12 @@ func main() {
 	public.Algorithm = "RS256"
 	public.Audience = apiHost
 	public.Issuer = apiHost
-	public.DurationSecs = 1000
+	public.DurationSecs = 60 * 60 * 24 * 30
 
 	private.EncodeKey = userSecret
 	private.DecodeKey = userSecret
 	private.Algorithm = "HS256"
-	private.DurationSecs = 1000
+	private.DurationSecs = 60 * 60 * 24 * 30
 
 	longTermKey, found := os.LookupEnv("LONG_TERM_KEY")
 	if found {

--- a/shoreline.go
+++ b/shoreline.go
@@ -79,10 +79,12 @@ func main() {
 	public.Algorithm = "RS256"
 	public.Audience = apiHost
 	public.Issuer = apiHost
+	public.DurationSecs = 1000
 
 	private.EncodeKey = userSecret
 	private.DecodeKey = userSecret
 	private.Algorithm = "HS256"
+	private.DurationSecs = 1000
 
 	longTermKey, found := os.LookupEnv("LONG_TERM_KEY")
 	if found {

--- a/shoreline.go
+++ b/shoreline.go
@@ -65,6 +65,13 @@ func main() {
 		config.User.LongTermKey = longTermKey
 	}
 
+	apiHost, found := os.LookupEnv("API_HOST")
+	if found {
+		config.User.APIHost = apiHost
+	} else {
+		config.User.APIHost = "localhost"
+	}
+
 	privateKey, found := os.LookupEnv("PRIVATE_KEY")
 	if found {
 		config.User.Secret = privateKey

--- a/shoreline.go
+++ b/shoreline.go
@@ -57,12 +57,22 @@ func main() {
 
 	userSecret, found := os.LookupEnv("API_SECRET")
 	if found {
-		config.User.Secret = userSecret
+		config.User.OldSecret = userSecret
 	}
 
 	longTermKey, found := os.LookupEnv("LONG_TERM_KEY")
 	if found {
 		config.User.LongTermKey = longTermKey
+	}
+
+	privateKey, found := os.LookupEnv("PRIVATE_KEY")
+	if found {
+		config.User.Secret = privateKey
+	}
+
+	publicKey, found := os.LookupEnv("PUBLIC_KEY")
+	if found {
+		config.User.PublicKey = publicKey
 	}
 
 	verificationSecret, found := os.LookupEnv("VERIFICATION_SECRET")

--- a/user/api.go
+++ b/user/api.go
@@ -656,7 +656,7 @@ func (a *Api) ServerLogin(res http.ResponseWriter, req *http.Request) {
 		if sessionToken, err := CreateSessionTokenAndSave(
 			&TokenData{DurationSecs: extractTokenDuration(req), UserId: server, IsServer: true},
 			TokenConfig{DurationSecs: a.ApiConfig.TokenDurationSecs, Secret: a.ApiConfig.Secret,
-				Issuer: a.ApiConfig.APIHost, Audience: a.ApiConfig.APIHost}
+				Issuer: a.ApiConfig.APIHost, Audience: a.ApiConfig.APIHost},
 			a.Store,
 		); err != nil {
 			a.logger.Println(http.StatusInternalServerError, STATUS_ERR_GENERATING_TOKEN, err.Error())
@@ -710,7 +710,7 @@ func (a *Api) oauth2Login(w http.ResponseWriter, r *http.Request) {
 				if sessionToken, err := CreateSessionTokenAndSave(
 					&TokenData{DurationSecs: 0, UserId: result["userId"].(string), IsServer: false},
 					TokenConfig{DurationSecs: a.ApiConfig.TokenDurationSecs, Secret: a.ApiConfig.Secret,
-						Issuer: a.ApiConfig.APIHost, Audience: a.ApiConfig.APIHost}
+						Issuer: a.ApiConfig.APIHost, Audience: a.ApiConfig.APIHost},
 					a.Store,
 				); err != nil {
 					a.logger.Println(http.StatusUnauthorized, "oauth2Login error creating session token", err.Error())
@@ -756,7 +756,7 @@ func (a *Api) RefreshSession(res http.ResponseWriter, req *http.Request) {
 	if sessionToken, err := CreateSessionTokenAndSave(
 		td,
 		TokenConfig{DurationSecs: a.ApiConfig.TokenDurationSecs, Secret: a.ApiConfig.Secret,
-			Issuer: a.ApiConfig.APIHost, Audience: a.ApiConfig.APIHost}
+			Issuer: a.ApiConfig.APIHost, Audience: a.ApiConfig.APIHost},
 		a.Store,
 	); err != nil {
 		a.logger.Println(http.StatusInternalServerError, STATUS_ERR_GENERATING_TOKEN, err.Error())

--- a/user/api.go
+++ b/user/api.go
@@ -787,8 +787,11 @@ func (a *Api) LongtermLogin(res http.ResponseWriter, req *http.Request, vars map
 // status: 404 STATUS_NO_TOKEN_MATCH
 func (a *Api) ServerCheckToken(res http.ResponseWriter, req *http.Request, vars map[string]string) {
 
-	if hasServerToken(req.Header.Get(TP_SESSION_TOKEN), a.ApiConfig.TokenConfigs[0]) ||
-		hasServerToken(req.Header.Get(TP_SESSION_TOKEN), a.ApiConfig.TokenConfigs[1]) {
+	var good bool
+	for _, tc := range a.ApiConfig.TokenConfigs {
+		good = good || hasServerToken(req.Header.Get(TP_SESSION_TOKEN), tc)
+	}
+	if good {
 		td, err := a.authenticateSessionToken(vars["token"])
 		if err != nil {
 			a.logger.Printf("failed request: %v", req)

--- a/user/api.go
+++ b/user/api.go
@@ -940,7 +940,7 @@ func (a *Api) sendError(res http.ResponseWriter, statusCode int, reason string, 
 func (a *Api) authenticateSessionToken(sessionToken string) (*TokenData, error) {
 	if sessionToken == "" {
 		return nil, errors.New("Session token is empty")
-	} else if tokenData, err := UnpackSessionTokenAndVerify(sessionToken, a.ApiConfig.Secret, a.ApiConfig.PublicKey); err != nil {
+	} else if tokenData, err := UnpackSessionTokenAndVerify(sessionToken, a.ApiConfig.OldSecret, a.ApiConfig.PublicKey); err != nil {
 		return nil, err
 	} else if _, err := a.Store.FindTokenByID(sessionToken); err != nil {
 		return nil, err

--- a/user/api.go
+++ b/user/api.go
@@ -787,11 +787,7 @@ func (a *Api) LongtermLogin(res http.ResponseWriter, req *http.Request, vars map
 // status: 404 STATUS_NO_TOKEN_MATCH
 func (a *Api) ServerCheckToken(res http.ResponseWriter, req *http.Request, vars map[string]string) {
 
-	var good bool
-	for _, tc := range a.ApiConfig.TokenConfigs {
-		good = good || hasServerToken(req.Header.Get(TP_SESSION_TOKEN), tc)
-	}
-	if good {
+	if hasServerToken(req.Header.Get(TP_SESSION_TOKEN), a.ApiConfig.TokenConfigs...) {
 		td, err := a.authenticateSessionToken(vars["token"])
 		if err != nil {
 			a.logger.Printf("failed request: %v", req)

--- a/user/api_test.go
+++ b/user/api_test.go
@@ -88,6 +88,7 @@ xwIDAQAB
 			DurationSecs: TOKEN_DURATION,
 			Audience:     "localhost",
 			Issuer:       "localhost",
+			Algorithm:    "RS256",
 		}},
 
 		LongTermKey:        "thelongtermkey",

--- a/user/api_test.go
+++ b/user/api_test.go
@@ -47,8 +47,43 @@ var (
 	NO_PARAMS      = map[string]string{}
 	TOKEN_DURATION = int64(3600)
 	FAKE_CONFIG    = ApiConfig{
-		ServerSecret:       "shhh! don't tell",
-		Secret:             "shhh! don't tell *2",
+		ServerSecret: "shhh! don't tell",
+		Secret: `-----BEGIN RSA PRIVATE KEY-----
+MIIEpAIBAAKCAQEAzg3MHpXfMuH4AJ4URtaG4QvZenpfuSz2FmIwdnPEtkrKFmL2
+6b89U1tw5WsYAE158znAzPptDA25hAsIcTAqULNsoY3WV2zmsLrUX8pUaCTfExXN
+dMFDruR676G3pJWcsI1GuePK5/v3dBHjjTYdtVJiogbCtP+XYT/k1qHZztwRY4oH
+Ma8LorxUZco0Mf6qOq5tmRUJhxvCESaqUTpTAIIfByMnPmnIHOHnsYtkiZQBms2x
+o1UfpYnqZX2CoN+wPoMoSAlRbnOmmHYbbMFVPNTj7NINwVb8K8iDU7lFR+JfN3UG
+lErVo7XCDQcbwTpiZbdj9zWSWbYtIBNBqkNxxwIDAQABAoIBAG3IMhmVlh6BAGYr
+0vfO8nvSmWNE8d0yFEbmt5VUptjMzhDRV2ZAascPr/27akU3AiNRgOR1BEZoxY+R
+ZUUQ+WqXvefxLuLTdbFxSRdkMEZwZp2/fwCWu53hw5IK4lIBGEOEccs2j3O77iJc
+KZWh4IArzbsvyOswRhIdPaoQ/3/TECPa5AXY7LAEj32XfP3K08rRAldgdfTv6XbV
+e/pzKMzqgPMIhZ3mG1n7CJ+DLhajEEG36KwszI6OttkjzyBzlsQb3rskEOypG3ZU
+k24B++v3Cm7FN0vG+FLFVzwS5rDrF+CUIFCyQU/nAB8nmkiNdCbDI0/614NeSSnE
+BZc6G1ECgYEA/zVJdpRx5kgFDyxmJrdVcXJ/digGDct6og0pffcJW1ygBnt+tLRd
+gpH+oBNUMz92GKb+wTTlOba0CNbJULM1sZklf604yzpIDji0HyI2oZ0fo+OEkpBz
+PyNrdnm2WXF4e3WCb1ehkxGMyfTH70RFKqmPRMka1xWAMXPgbP5Osj8CgYEAzrF3
+iAX+geyqagzQfbt5bf9zePmL4Dx6J37pgtZSo88sqtSU6+eYQsF/pS5KrtxD6Sql
+5qSbfKekmDhEF4DMUeva76JHmPIPdJH+fPyw6jOB6S3tS+i41S2CGNub1RLz7LCj
+NEZ9H5GBVmxBTdiZL3aZWgIxo63Nl0H39k6+TnkCgYEA44Nkx5LU659+6yUAuDku
+seGKIhLSOtAQtpEXUVW/ALTVcJH9xikZSALRRXGV2c4UgSu25xU52Ta4zzxz4j6x
+em92D5mkjQCbJhqE8VB19aP2hguZr3OZWktATTF6T8ipyR5cNtifkVXO9mgDKZnq
+M3tP3tmN1Ps0+mE8TM51588CgYBZYgtz6kuued8UL2h2Bv2zINYZyajAlsaoj8yB
+hReFuVDyqy2feq6wp6cAkq0/QwenLIdD34lR9dlK7oIbu9ofzyQFnyLhNESUv5HT
+ER+cmBuk7/R/cCuGHMD26PlRwnlzsMtTDuyLG0xYSEZRWMqd6ObWMr6urrmKoL+P
+Z2wK2QKBgQC7SZ47YM45pz23yjyrKx6dUAfw5imb6ylZPft24A+W2tFanfRDQITX
+wGHgJHaV+gd52zrP6s8AKzMjMcRtB0g0CGf5Qe1BHMh89fJsUKToT8L+040kWl/P
+upYmRYNT7J2Met0WVB6u6ZDFSMl+CIFLXHGtU47DjGUmQxqmhW8LOg==
+-----END RSA PRIVATE KEY-----`,
+		PublicKey: `-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAzg3MHpXfMuH4AJ4URtaG
+4QvZenpfuSz2FmIwdnPEtkrKFmL26b89U1tw5WsYAE158znAzPptDA25hAsIcTAq
+ULNsoY3WV2zmsLrUX8pUaCTfExXNdMFDruR676G3pJWcsI1GuePK5/v3dBHjjTYd
+tVJiogbCtP+XYT/k1qHZztwRY4oHMa8LorxUZco0Mf6qOq5tmRUJhxvCESaqUTpT
+AIIfByMnPmnIHOHnsYtkiZQBms2xo1UfpYnqZX2CoN+wPoMoSAlRbnOmmHYbbMFV
+PNTj7NINwVb8K8iDU7lFR+JfN3UGlErVo7XCDQcbwTpiZbdj9zWSWbYtIBNBqkNx
+xwIDAQAB
+-----END PUBLIC KEY-----`,
 		TokenDurationSecs:  TOKEN_DURATION,
 		LongTermKey:        "thelongtermkey",
 		Salt:               "a mineral substance composed primarily of sodium chloride",
@@ -66,7 +101,7 @@ var (
 	/*
 	 * users and tokens
 	 */
-	TOKEN_CONFIG  = TokenConfig{DurationSecs: FAKE_CONFIG.TokenDurationSecs, Secret: FAKE_CONFIG.Secret}
+	TOKEN_CONFIG  = TokenConfig{DurationSecs: FAKE_CONFIG.TokenDurationSecs, Secret: FAKE_CONFIG.Secret, PublicKey: FAKE_CONFIG.PublicKey}
 	USR           = &User{Id: "123-99-100", Username: "test@new.bar", Emails: []string{"test@new.bar"}}
 	USR_TOKEN, _  = CreateSessionToken(&TokenData{UserId: USR.Id, IsServer: false, DurationSecs: TOKEN_DURATION}, TOKEN_CONFIG)
 	SRVR_TOKEN, _ = CreateSessionToken(&TokenData{UserId: "shoreline", IsServer: true, DurationSecs: TOKEN_DURATION}, TOKEN_CONFIG)
@@ -108,6 +143,7 @@ func InitShoreline(config ApiConfig, store Storage, metrics highwater.Client, pe
 // creating a mock Marketo Manager
 type MockManager struct {
 }
+
 func (U *MockManager) CreateListMembershipForUser(newUser marketo.User) {
 
 }
@@ -1852,7 +1888,7 @@ func TestHasServerToken_True(t *testing.T) {
 		t.Fatal("The session token should have been set")
 	}
 
-	if hasServerToken(response.Header().Get(TP_SESSION_TOKEN), shoreline.ApiConfig.Secret) == false {
+	if hasServerToken(response.Header().Get(TP_SESSION_TOKEN), shoreline.ApiConfig.PublicKey) == false {
 		t.Fatal("The token should have been a valid server token")
 	}
 }

--- a/user/mongoStoreClient_test.go
+++ b/user/mongoStoreClient_test.go
@@ -257,8 +257,9 @@ func TestMongoStore_FindUsersById(t *testing.T) {
 func TestMongoStoreTokenOperations(t *testing.T) {
 
 	testing_token_data := &TokenData{UserId: "2341", IsServer: true, DurationSecs: 3600}
-	testing_token_config := TokenConfig{DurationSecs: 1200,
-		Secret: `-----BEGIN RSA PRIVATE KEY-----
+	testing_token_config := TokenConfig{
+		DurationSecs: 1200,
+		EncodeKey: `-----BEGIN RSA PRIVATE KEY-----
 MIIEpAIBAAKCAQEAzg3MHpXfMuH4AJ4URtaG4QvZenpfuSz2FmIwdnPEtkrKFmL2
 6b89U1tw5WsYAE158znAzPptDA25hAsIcTAqULNsoY3WV2zmsLrUX8pUaCTfExXN
 dMFDruR676G3pJWcsI1GuePK5/v3dBHjjTYdtVJiogbCtP+XYT/k1qHZztwRY4oH
@@ -285,7 +286,7 @@ Z2wK2QKBgQC7SZ47YM45pz23yjyrKx6dUAfw5imb6ylZPft24A+W2tFanfRDQITX
 wGHgJHaV+gd52zrP6s8AKzMjMcRtB0g0CGf5Qe1BHMh89fJsUKToT8L+040kWl/P
 upYmRYNT7J2Met0WVB6u6ZDFSMl+CIFLXHGtU47DjGUmQxqmhW8LOg==
 -----END RSA PRIVATE KEY-----`,
-		PublicKey: `-----BEGIN PUBLIC KEY-----
+		DecodeKey: `-----BEGIN PUBLIC KEY-----
 MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAzg3MHpXfMuH4AJ4URtaG
 4QvZenpfuSz2FmIwdnPEtkrKFmL26b89U1tw5WsYAE158znAzPptDA25hAsIcTAq
 ULNsoY3WV2zmsLrUX8pUaCTfExXNdMFDruR676G3pJWcsI1GuePK5/v3dBHjjTYd
@@ -293,7 +294,11 @@ tVJiogbCtP+XYT/k1qHZztwRY4oHMa8LorxUZco0Mf6qOq5tmRUJhxvCESaqUTpT
 AIIfByMnPmnIHOHnsYtkiZQBms2xo1UfpYnqZX2CoN+wPoMoSAlRbnOmmHYbbMFV
 PNTj7NINwVb8K8iDU7lFR+JfN3UGlErVo7XCDQcbwTpiZbdj9zWSWbYtIBNBqkNx
 xwIDAQAB
------END PUBLIC KEY-----`}
+-----END PUBLIC KEY-----`,
+		Algorithm: "RS256",
+		Audience:  "localhost",
+		Issuer:    "localhost",
+	}
 
 	mc, err := mgoTestSetup()
 	if err != nil {

--- a/user/mongoStoreClient_test.go
+++ b/user/mongoStoreClient_test.go
@@ -257,7 +257,43 @@ func TestMongoStore_FindUsersById(t *testing.T) {
 func TestMongoStoreTokenOperations(t *testing.T) {
 
 	testing_token_data := &TokenData{UserId: "2341", IsServer: true, DurationSecs: 3600}
-	testing_token_config := TokenConfig{DurationSecs: 1200, Secret: "some secret for the tests"}
+	testing_token_config := TokenConfig{DurationSecs: 1200,
+		Secret: `-----BEGIN RSA PRIVATE KEY-----
+MIIEpAIBAAKCAQEAzg3MHpXfMuH4AJ4URtaG4QvZenpfuSz2FmIwdnPEtkrKFmL2
+6b89U1tw5WsYAE158znAzPptDA25hAsIcTAqULNsoY3WV2zmsLrUX8pUaCTfExXN
+dMFDruR676G3pJWcsI1GuePK5/v3dBHjjTYdtVJiogbCtP+XYT/k1qHZztwRY4oH
+Ma8LorxUZco0Mf6qOq5tmRUJhxvCESaqUTpTAIIfByMnPmnIHOHnsYtkiZQBms2x
+o1UfpYnqZX2CoN+wPoMoSAlRbnOmmHYbbMFVPNTj7NINwVb8K8iDU7lFR+JfN3UG
+lErVo7XCDQcbwTpiZbdj9zWSWbYtIBNBqkNxxwIDAQABAoIBAG3IMhmVlh6BAGYr
+0vfO8nvSmWNE8d0yFEbmt5VUptjMzhDRV2ZAascPr/27akU3AiNRgOR1BEZoxY+R
+ZUUQ+WqXvefxLuLTdbFxSRdkMEZwZp2/fwCWu53hw5IK4lIBGEOEccs2j3O77iJc
+KZWh4IArzbsvyOswRhIdPaoQ/3/TECPa5AXY7LAEj32XfP3K08rRAldgdfTv6XbV
+e/pzKMzqgPMIhZ3mG1n7CJ+DLhajEEG36KwszI6OttkjzyBzlsQb3rskEOypG3ZU
+k24B++v3Cm7FN0vG+FLFVzwS5rDrF+CUIFCyQU/nAB8nmkiNdCbDI0/614NeSSnE
+BZc6G1ECgYEA/zVJdpRx5kgFDyxmJrdVcXJ/digGDct6og0pffcJW1ygBnt+tLRd
+gpH+oBNUMz92GKb+wTTlOba0CNbJULM1sZklf604yzpIDji0HyI2oZ0fo+OEkpBz
+PyNrdnm2WXF4e3WCb1ehkxGMyfTH70RFKqmPRMka1xWAMXPgbP5Osj8CgYEAzrF3
+iAX+geyqagzQfbt5bf9zePmL4Dx6J37pgtZSo88sqtSU6+eYQsF/pS5KrtxD6Sql
+5qSbfKekmDhEF4DMUeva76JHmPIPdJH+fPyw6jOB6S3tS+i41S2CGNub1RLz7LCj
+NEZ9H5GBVmxBTdiZL3aZWgIxo63Nl0H39k6+TnkCgYEA44Nkx5LU659+6yUAuDku
+seGKIhLSOtAQtpEXUVW/ALTVcJH9xikZSALRRXGV2c4UgSu25xU52Ta4zzxz4j6x
+em92D5mkjQCbJhqE8VB19aP2hguZr3OZWktATTF6T8ipyR5cNtifkVXO9mgDKZnq
+M3tP3tmN1Ps0+mE8TM51588CgYBZYgtz6kuued8UL2h2Bv2zINYZyajAlsaoj8yB
+hReFuVDyqy2feq6wp6cAkq0/QwenLIdD34lR9dlK7oIbu9ofzyQFnyLhNESUv5HT
+ER+cmBuk7/R/cCuGHMD26PlRwnlzsMtTDuyLG0xYSEZRWMqd6ObWMr6urrmKoL+P
+Z2wK2QKBgQC7SZ47YM45pz23yjyrKx6dUAfw5imb6ylZPft24A+W2tFanfRDQITX
+wGHgJHaV+gd52zrP6s8AKzMjMcRtB0g0CGf5Qe1BHMh89fJsUKToT8L+040kWl/P
+upYmRYNT7J2Met0WVB6u6ZDFSMl+CIFLXHGtU47DjGUmQxqmhW8LOg==
+-----END RSA PRIVATE KEY-----`,
+		PublicKey: `-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAzg3MHpXfMuH4AJ4URtaG
+4QvZenpfuSz2FmIwdnPEtkrKFmL26b89U1tw5WsYAE158znAzPptDA25hAsIcTAq
+ULNsoY3WV2zmsLrUX8pUaCTfExXNdMFDruR676G3pJWcsI1GuePK5/v3dBHjjTYd
+tVJiogbCtP+XYT/k1qHZztwRY4oHMa8LorxUZco0Mf6qOq5tmRUJhxvCESaqUTpT
+AIIfByMnPmnIHOHnsYtkiZQBms2xo1UfpYnqZX2CoN+wPoMoSAlRbnOmmHYbbMFV
+PNTj7NINwVb8K8iDU7lFR+JfN3UGlErVo7XCDQcbwTpiZbdj9zWSWbYtIBNBqkNx
+xwIDAQAB
+-----END PUBLIC KEY-----`}
 
 	mc, err := mgoTestSetup()
 	if err != nil {

--- a/user/token.go
+++ b/user/token.go
@@ -118,6 +118,8 @@ func CreateSessionTokenAndSave(data *TokenData, config TokenConfig, store Storag
 
 	_, err = UnpackSessionTokenAndVerify(sessionToken.ID, config)
 	if err != nil {
+		log.Printf("failed to verify new session token %v", sessionToken.ID)
+		log.Printf("config %v", config)
 		return nil, err
 	}
 

--- a/user/token.go
+++ b/user/token.go
@@ -32,6 +32,8 @@ type (
 		Secret       string
 		DurationSecs int64
 		PublicKey    string
+		Audience     string
+		Issuer       string
 	}
 )
 
@@ -71,9 +73,17 @@ func CreateSessionToken(data *TokenData, config TokenConfig) (*SessionToken, err
 	token.Claims["usr"] = data.UserId
 	token.Claims["dur"] = data.DurationSecs
 	token.Claims["exp"] = expiresAt
-	token.Claims["iss"] = "tidepool/shoreline"
+	if config.Issuer == "" {
+		token.Claims["iss"] = "localhost"
+	} else {
+		token.Claims["iss"] = config.Issuer
+	}
 	token.Claims["sub"] = data.UserId
-	token.Claims["aud"] = "tidepool"
+	if config.Audience == "" {
+		token.Claims["aud"] = "localhost"
+	} else {
+		token.Claims["aud"] = config.Audience
+	}
 	token.Claims["iam"] = createdAt
 
 	tokenString, err := token.SignedString([]byte(config.Secret))

--- a/user/token.go
+++ b/user/token.go
@@ -84,7 +84,7 @@ func CreateSessionToken(data *TokenData, config TokenConfig) (*SessionToken, err
 	} else {
 		token.Claims["aud"] = config.Audience
 	}
-	token.Claims["iam"] = createdAt
+	token.Claims["iat"] = createdAt
 
 	tokenString, err := token.SignedString([]byte(config.Secret))
 	if err != nil {

--- a/user/token.go
+++ b/user/token.go
@@ -116,6 +116,11 @@ func CreateSessionTokenAndSave(data *TokenData, config TokenConfig, store Storag
 		return nil, err
 	}
 
+	_, err = UnpackSessionTokenAndVerify(sessionToken.ID, config)
+	if err != nil {
+		return nil, err
+	}
+
 	err = store.AddToken(sessionToken)
 	if err != nil {
 		return nil, err

--- a/user/token.go
+++ b/user/token.go
@@ -172,8 +172,8 @@ func extractTokenDuration(r *http.Request) int64 {
 	return 0
 }
 
-func hasServerToken(tokenString string, tokenConfig TokenConfig) bool {
-	td, err := UnpackSessionTokenAndVerify(tokenString, tokenConfig)
+func hasServerToken(tokenString string, tokenConfigs ...TokenConfig) bool {
+	td, err := UnpackSessionTokenAndVerify(tokenString, tokenConfigs...)
 	if err != nil {
 		return false
 	}

--- a/user/token.go
+++ b/user/token.go
@@ -139,6 +139,7 @@ func UnpackSessionTokenAndVerify(id string, tokenConfigs ...TokenConfig) (*Token
 	var jwtToken *jwt.Token
 	var err error
 	for _, tokenConfig := range tokenConfigs {
+		log.Printf("using %v", tokenConfig)
 		jwtToken, err = jwt.Parse(id, func(t *jwt.Token) ([]byte, error) { return []byte(tokenConfig.DecodeKey), nil })
 		if err == nil {
 			break

--- a/user/token.go
+++ b/user/token.go
@@ -139,7 +139,6 @@ func UnpackSessionTokenAndVerify(id string, tokenConfigs ...TokenConfig) (*Token
 	var jwtToken *jwt.Token
 	var err error
 	for _, tokenConfig := range tokenConfigs {
-		log.Printf("using %v", tokenConfig)
 		jwtToken, err = jwt.Parse(id, func(t *jwt.Token) ([]byte, error) { return []byte(tokenConfig.DecodeKey), nil })
 		if err == nil {
 			break

--- a/user/token.go
+++ b/user/token.go
@@ -2,6 +2,7 @@ package user
 
 import (
 	"errors"
+	"log"
 	"net/http"
 	"strconv"
 	"time"
@@ -77,6 +78,7 @@ func CreateSessionToken(data *TokenData, config TokenConfig) (*SessionToken, err
 
 	tokenString, err := token.SignedString([]byte(config.Secret))
 	if err != nil {
+		log.Print("failed to sign")
 		return nil, err
 	}
 

--- a/user/token_test.go
+++ b/user/token_test.go
@@ -50,8 +50,9 @@ AIIfByMnPmnIHOHnsYtkiZQBms2xo1UfpYnqZX2CoN+wPoMoSAlRbnOmmHYbbMFV
 PNTj7NINwVb8K8iDU7lFR+JfN3UGlErVo7XCDQcbwTpiZbdj9zWSWbYtIBNBqkNx
 xwIDAQAB
 -----END PUBLIC KEY-----`,
-	Audience: "localhost",
-	Issuer:   "localhsot",
+	Audience:  "localhost",
+	Issuer:    "localhsot",
+	Algorithm: "RS256",
 }
 
 func Test_GenerateSessionToken(t *testing.T) {

--- a/user/token_test.go
+++ b/user/token_test.go
@@ -14,7 +14,7 @@ type tokenTestData struct {
 
 var tokenConfig = TokenConfig{
 	DurationSecs: 3600,
-	Secret: `-----BEGIN RSA PRIVATE KEY-----
+	EncodeKey: `-----BEGIN RSA PRIVATE KEY-----
 MIIEpAIBAAKCAQEAzg3MHpXfMuH4AJ4URtaG4QvZenpfuSz2FmIwdnPEtkrKFmL2
 6b89U1tw5WsYAE158znAzPptDA25hAsIcTAqULNsoY3WV2zmsLrUX8pUaCTfExXN
 dMFDruR676G3pJWcsI1GuePK5/v3dBHjjTYdtVJiogbCtP+XYT/k1qHZztwRY4oH
@@ -41,7 +41,7 @@ Z2wK2QKBgQC7SZ47YM45pz23yjyrKx6dUAfw5imb6ylZPft24A+W2tFanfRDQITX
 wGHgJHaV+gd52zrP6s8AKzMjMcRtB0g0CGf5Qe1BHMh89fJsUKToT8L+040kWl/P
 upYmRYNT7J2Met0WVB6u6ZDFSMl+CIFLXHGtU47DjGUmQxqmhW8LOg==
 -----END RSA PRIVATE KEY-----`,
-	PublicKey: `-----BEGIN PUBLIC KEY-----
+	DecodeKey: `-----BEGIN PUBLIC KEY-----
 MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAzg3MHpXfMuH4AJ4URtaG
 4QvZenpfuSz2FmIwdnPEtkrKFmL26b89U1tw5WsYAE158znAzPptDA25hAsIcTAq
 ULNsoY3WV2zmsLrUX8pUaCTfExXNdMFDruR676G3pJWcsI1GuePK5/v3dBHjjTYd
@@ -50,6 +50,8 @@ AIIfByMnPmnIHOHnsYtkiZQBms2xo1UfpYnqZX2CoN+wPoMoSAlRbnOmmHYbbMFV
 PNTj7NINwVb8K8iDU7lFR+JfN3UGlErVo7XCDQcbwTpiZbdj9zWSWbYtIBNBqkNx
 xwIDAQAB
 -----END PUBLIC KEY-----`,
+	Audience: "localhost",
+	Issuer:   "localhsot",
 }
 
 func Test_GenerateSessionToken(t *testing.T) {
@@ -60,13 +62,13 @@ func Test_GenerateSessionToken(t *testing.T) {
 	}
 
 	//given duration seconds trump the configured duration
-	token, _ := CreateSessionToken(testData.data, testData.config)
+	token, _ := CreateSessionToken(testData.data, tokenConfig)
 
 	if token.ID == "" {
 		t.Fatalf("should generate a session token with an ID set")
 	}
 
-	td, _ := UnpackSessionTokenAndVerify(token.ID, tokenConfig.PublicKey)
+	td, _ := UnpackSessionTokenAndVerify(token.ID, tokenConfig)
 
 	if td.DurationSecs != testData.data.DurationSecs {
 		t.Fatalf("we should use the DurationSecs if given")
@@ -81,13 +83,13 @@ func Test_GenerateSessionToken_DurationFromConfig(t *testing.T) {
 	}
 
 	//given duration seconds trump the configured duration
-	token, _ := CreateSessionToken(testData.data, testData.config)
+	token, _ := CreateSessionToken(testData.data, tokenConfig)
 
 	if token.ID == "" || token.Time == 0 {
 		t.Fatalf("should generate a session token")
 	}
 
-	td, _ := UnpackSessionTokenAndVerify(token.ID, tokenConfig.PublicKey)
+	td, _ := UnpackSessionTokenAndVerify(token.ID, tokenConfig)
 
 	if td.DurationSecs != tokenConfig.DurationSecs {
 		t.Fatalf("the duration should be from config")
@@ -101,13 +103,13 @@ func Test_GenerateSessionToken_DurationSecsTrumpConfig(t *testing.T) {
 		config: tokenConfig,
 	}
 
-	token, _ := CreateSessionToken(testData.data, testData.config)
+	token, _ := CreateSessionToken(testData.data, tokenConfig)
 
 	if token.ID == "" || token.Time == 0 {
 		t.Fatalf("should generate a session token")
 	}
 
-	td, _ := UnpackSessionTokenAndVerify(token.ID, tokenConfig.PublicKey)
+	td, _ := UnpackSessionTokenAndVerify(token.ID, tokenConfig)
 
 	if td.DurationSecs != testData.data.DurationSecs {
 		t.Fatalf("the duration should come from the token data")
@@ -122,7 +124,7 @@ func Test_GenerateSessionToken_NoUserId(t *testing.T) {
 		config: tokenConfig,
 	}
 
-	if _, err := CreateSessionToken(testData.data, testData.config); err == nil {
+	if _, err := CreateSessionToken(testData.data, tokenConfig); err == nil {
 		t.Fatalf("should not generate a session token if there is no userid")
 	}
 }
@@ -134,13 +136,13 @@ func Test_GenerateSessionToken_Server(t *testing.T) {
 		config: tokenConfig,
 	}
 
-	token, _ := CreateSessionToken(testData.data, testData.config)
+	token, _ := CreateSessionToken(testData.data, tokenConfig)
 
 	if token.ID == "" || token.Time == 0 {
 		t.Fatalf("should generate a session token")
 	}
 
-	td, _ := UnpackSessionTokenAndVerify(token.ID, tokenConfig.PublicKey)
+	td, _ := UnpackSessionTokenAndVerify(token.ID, tokenConfig)
 
 	if td.IsServer != true {
 		t.Fatal("this should be a server token")
@@ -159,9 +161,9 @@ func Test_UnpackedData(t *testing.T) {
 		config: tokenConfig,
 	}
 
-	token, _ := CreateSessionToken(testData.data, testData.config)
+	token, _ := CreateSessionToken(testData.data, tokenConfig)
 
-	data, err := UnpackSessionTokenAndVerify(token.ID, testData.config.PublicKey)
+	data, err := UnpackSessionTokenAndVerify(token.ID, tokenConfig)
 	if err != nil {
 		t.Fatal("unpacked token should be valid", err.Error())
 	}
@@ -187,11 +189,11 @@ func Test_UnpackTokenExpires(t *testing.T) {
 		config: tokenConfig,
 	}
 
-	token, _ := CreateSessionToken(testData.data, testData.config)
+	token, _ := CreateSessionToken(testData.data, tokenConfig)
 
 	time.Sleep(2 * time.Second) //ensure token expires
 
-	data, err := UnpackSessionTokenAndVerify(token.ID, testData.config.PublicKey)
+	data, err := UnpackSessionTokenAndVerify(token.ID, tokenConfig)
 
 	if data != nil {
 		t.Fatal("the token should have expired")
@@ -210,9 +212,9 @@ func Test_UnpackAndVerifyStoredToken(t *testing.T) {
 		config: tokenConfig,
 	}
 
-	token, _ := CreateSessionToken(testData.data, testData.config)
+	token, _ := CreateSessionToken(testData.data, tokenConfig)
 
-	_, err := UnpackSessionTokenAndVerify(token.ID, testData.config.PublicKey)
+	_, err := UnpackSessionTokenAndVerify(token.ID, tokenConfig)
 
 	if err != nil {
 		t.Fatal("the token should be valid", err.Error())
@@ -242,9 +244,9 @@ func Test_getUnpackedToken(t *testing.T) {
 		config: tokenConfig,
 	}
 
-	token, _ := CreateSessionToken(testData.data, testData.config)
+	token, _ := CreateSessionToken(testData.data, tokenConfig)
 
-	td, err := UnpackSessionTokenAndVerify(token.ID, testData.config.PublicKey)
+	td, err := UnpackSessionTokenAndVerify(token.ID, tokenConfig)
 	if err != nil {
 		t.Fatal("We should have got TokenData")
 	}
@@ -261,9 +263,9 @@ func Test_hasServerToken(t *testing.T) {
 		config: tokenConfig,
 	}
 
-	token, _ := CreateSessionToken(testData.data, testData.config)
+	token, _ := CreateSessionToken(testData.data, tokenConfig)
 
-	if hasServerToken(token.ID, testData.config.PublicKey) == false {
+	if hasServerToken(token.ID, tokenConfig) == false {
 		t.Fatal("We should have got a server Token")
 	}
 }
@@ -274,9 +276,9 @@ func Test_hasServerToken_false(t *testing.T) {
 		config: tokenConfig,
 	}
 
-	token, _ := CreateSessionToken(testData.data, testData.config)
+	token, _ := CreateSessionToken(testData.data, tokenConfig)
 
-	if hasServerToken(token.ID, testData.config.PublicKey) != false {
+	if hasServerToken(token.ID, tokenConfig) != false {
 		t.Fatal("We should have not got a server Token")
 	}
 }

--- a/user/token_test.go
+++ b/user/token_test.go
@@ -14,7 +14,42 @@ type tokenTestData struct {
 
 var tokenConfig = TokenConfig{
 	DurationSecs: 3600,
-	Secret:       "my secret",
+	Secret: `-----BEGIN RSA PRIVATE KEY-----
+MIIEpAIBAAKCAQEAzg3MHpXfMuH4AJ4URtaG4QvZenpfuSz2FmIwdnPEtkrKFmL2
+6b89U1tw5WsYAE158znAzPptDA25hAsIcTAqULNsoY3WV2zmsLrUX8pUaCTfExXN
+dMFDruR676G3pJWcsI1GuePK5/v3dBHjjTYdtVJiogbCtP+XYT/k1qHZztwRY4oH
+Ma8LorxUZco0Mf6qOq5tmRUJhxvCESaqUTpTAIIfByMnPmnIHOHnsYtkiZQBms2x
+o1UfpYnqZX2CoN+wPoMoSAlRbnOmmHYbbMFVPNTj7NINwVb8K8iDU7lFR+JfN3UG
+lErVo7XCDQcbwTpiZbdj9zWSWbYtIBNBqkNxxwIDAQABAoIBAG3IMhmVlh6BAGYr
+0vfO8nvSmWNE8d0yFEbmt5VUptjMzhDRV2ZAascPr/27akU3AiNRgOR1BEZoxY+R
+ZUUQ+WqXvefxLuLTdbFxSRdkMEZwZp2/fwCWu53hw5IK4lIBGEOEccs2j3O77iJc
+KZWh4IArzbsvyOswRhIdPaoQ/3/TECPa5AXY7LAEj32XfP3K08rRAldgdfTv6XbV
+e/pzKMzqgPMIhZ3mG1n7CJ+DLhajEEG36KwszI6OttkjzyBzlsQb3rskEOypG3ZU
+k24B++v3Cm7FN0vG+FLFVzwS5rDrF+CUIFCyQU/nAB8nmkiNdCbDI0/614NeSSnE
+BZc6G1ECgYEA/zVJdpRx5kgFDyxmJrdVcXJ/digGDct6og0pffcJW1ygBnt+tLRd
+gpH+oBNUMz92GKb+wTTlOba0CNbJULM1sZklf604yzpIDji0HyI2oZ0fo+OEkpBz
+PyNrdnm2WXF4e3WCb1ehkxGMyfTH70RFKqmPRMka1xWAMXPgbP5Osj8CgYEAzrF3
+iAX+geyqagzQfbt5bf9zePmL4Dx6J37pgtZSo88sqtSU6+eYQsF/pS5KrtxD6Sql
+5qSbfKekmDhEF4DMUeva76JHmPIPdJH+fPyw6jOB6S3tS+i41S2CGNub1RLz7LCj
+NEZ9H5GBVmxBTdiZL3aZWgIxo63Nl0H39k6+TnkCgYEA44Nkx5LU659+6yUAuDku
+seGKIhLSOtAQtpEXUVW/ALTVcJH9xikZSALRRXGV2c4UgSu25xU52Ta4zzxz4j6x
+em92D5mkjQCbJhqE8VB19aP2hguZr3OZWktATTF6T8ipyR5cNtifkVXO9mgDKZnq
+M3tP3tmN1Ps0+mE8TM51588CgYBZYgtz6kuued8UL2h2Bv2zINYZyajAlsaoj8yB
+hReFuVDyqy2feq6wp6cAkq0/QwenLIdD34lR9dlK7oIbu9ofzyQFnyLhNESUv5HT
+ER+cmBuk7/R/cCuGHMD26PlRwnlzsMtTDuyLG0xYSEZRWMqd6ObWMr6urrmKoL+P
+Z2wK2QKBgQC7SZ47YM45pz23yjyrKx6dUAfw5imb6ylZPft24A+W2tFanfRDQITX
+wGHgJHaV+gd52zrP6s8AKzMjMcRtB0g0CGf5Qe1BHMh89fJsUKToT8L+040kWl/P
+upYmRYNT7J2Met0WVB6u6ZDFSMl+CIFLXHGtU47DjGUmQxqmhW8LOg==
+-----END RSA PRIVATE KEY-----`,
+	PublicKey: `-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAzg3MHpXfMuH4AJ4URtaG
+4QvZenpfuSz2FmIwdnPEtkrKFmL26b89U1tw5WsYAE158znAzPptDA25hAsIcTAq
+ULNsoY3WV2zmsLrUX8pUaCTfExXNdMFDruR676G3pJWcsI1GuePK5/v3dBHjjTYd
+tVJiogbCtP+XYT/k1qHZztwRY4oHMa8LorxUZco0Mf6qOq5tmRUJhxvCESaqUTpT
+AIIfByMnPmnIHOHnsYtkiZQBms2xo1UfpYnqZX2CoN+wPoMoSAlRbnOmmHYbbMFV
+PNTj7NINwVb8K8iDU7lFR+JfN3UGlErVo7XCDQcbwTpiZbdj9zWSWbYtIBNBqkNx
+xwIDAQAB
+-----END PUBLIC KEY-----`,
 }
 
 func Test_GenerateSessionToken(t *testing.T) {
@@ -31,7 +66,7 @@ func Test_GenerateSessionToken(t *testing.T) {
 		t.Fatalf("should generate a session token with an ID set")
 	}
 
-	td, _ := UnpackSessionTokenAndVerify(token.ID, tokenConfig.Secret)
+	td, _ := UnpackSessionTokenAndVerify(token.ID, tokenConfig.PublicKey)
 
 	if td.DurationSecs != testData.data.DurationSecs {
 		t.Fatalf("we should use the DurationSecs if given")
@@ -52,7 +87,7 @@ func Test_GenerateSessionToken_DurationFromConfig(t *testing.T) {
 		t.Fatalf("should generate a session token")
 	}
 
-	td, _ := UnpackSessionTokenAndVerify(token.ID, tokenConfig.Secret)
+	td, _ := UnpackSessionTokenAndVerify(token.ID, tokenConfig.PublicKey)
 
 	if td.DurationSecs != tokenConfig.DurationSecs {
 		t.Fatalf("the duration should be from config")
@@ -72,7 +107,7 @@ func Test_GenerateSessionToken_DurationSecsTrumpConfig(t *testing.T) {
 		t.Fatalf("should generate a session token")
 	}
 
-	td, _ := UnpackSessionTokenAndVerify(token.ID, tokenConfig.Secret)
+	td, _ := UnpackSessionTokenAndVerify(token.ID, tokenConfig.PublicKey)
 
 	if td.DurationSecs != testData.data.DurationSecs {
 		t.Fatalf("the duration should come from the token data")
@@ -105,7 +140,7 @@ func Test_GenerateSessionToken_Server(t *testing.T) {
 		t.Fatalf("should generate a session token")
 	}
 
-	td, _ := UnpackSessionTokenAndVerify(token.ID, tokenConfig.Secret)
+	td, _ := UnpackSessionTokenAndVerify(token.ID, tokenConfig.PublicKey)
 
 	if td.IsServer != true {
 		t.Fatal("this should be a server token")
@@ -126,7 +161,7 @@ func Test_UnpackedData(t *testing.T) {
 
 	token, _ := CreateSessionToken(testData.data, testData.config)
 
-	data, err := UnpackSessionTokenAndVerify(token.ID, testData.config.Secret)
+	data, err := UnpackSessionTokenAndVerify(token.ID, testData.config.PublicKey)
 	if err != nil {
 		t.Fatal("unpacked token should be valid", err.Error())
 	}
@@ -156,7 +191,7 @@ func Test_UnpackTokenExpires(t *testing.T) {
 
 	time.Sleep(2 * time.Second) //ensure token expires
 
-	data, err := UnpackSessionTokenAndVerify(token.ID, testData.config.Secret)
+	data, err := UnpackSessionTokenAndVerify(token.ID, testData.config.PublicKey)
 
 	if data != nil {
 		t.Fatal("the token should have expired")
@@ -177,7 +212,7 @@ func Test_UnpackAndVerifyStoredToken(t *testing.T) {
 
 	token, _ := CreateSessionToken(testData.data, testData.config)
 
-	_, err := UnpackSessionTokenAndVerify(token.ID, testData.config.Secret)
+	_, err := UnpackSessionTokenAndVerify(token.ID, testData.config.PublicKey)
 
 	if err != nil {
 		t.Fatal("the token should be valid", err.Error())
@@ -209,7 +244,7 @@ func Test_getUnpackedToken(t *testing.T) {
 
 	token, _ := CreateSessionToken(testData.data, testData.config)
 
-	td, err := UnpackSessionTokenAndVerify(token.ID, testData.config.Secret)
+	td, err := UnpackSessionTokenAndVerify(token.ID, testData.config.PublicKey)
 	if err != nil {
 		t.Fatal("We should have got TokenData")
 	}
@@ -228,7 +263,7 @@ func Test_hasServerToken(t *testing.T) {
 
 	token, _ := CreateSessionToken(testData.data, testData.config)
 
-	if hasServerToken(token.ID, testData.config.Secret) == false {
+	if hasServerToken(token.ID, testData.config.PublicKey) == false {
 		t.Fatal("We should have got a server Token")
 	}
 }
@@ -241,7 +276,7 @@ func Test_hasServerToken_false(t *testing.T) {
 
 	token, _ := CreateSessionToken(testData.data, testData.config)
 
-	if hasServerToken(token.ID, testData.config.Secret) != false {
+	if hasServerToken(token.ID, testData.config.PublicKey) != false {
 		t.Fatal("We should have not got a server Token")
 	}
 }


### PR DESCRIPTION
This is a backward compatible change to the way JWT session tokens are generated. The goal is to allow the use of standard authentication mechanisms.

This change adds new, standard claims.

It also switches to using public key encryption. 

To maintain backward compatibility, it accepts old shared key encrypted tokens. After a day or so of deployment, when all the old tokens are expired, the support for old shared key encrypted tokens will be removed.