### PR TITLE
[BACK-2043] Fix regression which allows creating users with duplicate email addesses

### DIFF
--- a/user/api.go
+++ b/user/api.go
@@ -381,10 +381,10 @@ func (a *Api) UpdateUser(res http.ResponseWriter, req *http.Request, vars map[st
 		if updateUserDetails.Username != nil || updateUserDetails.Emails != nil {
 			dupCheck := &User{}
 			if updateUserDetails.Username != nil {
-				dupCheck.Username = updatedUser.Username
+				dupCheck.Username = *updateUserDetails.Username
 			}
 			if updateUserDetails.Emails != nil {
-				dupCheck.Emails = updatedUser.Emails
+				dupCheck.Emails = updateUserDetails.Emails
 			}
 
 			if results, err := a.Store.WithContext(req.Context()).FindUsers(dupCheck); err != nil {


### PR DESCRIPTION
The regression was introduced in c16aa7d. It allowed setting an already taken email address if the account that was being edited had an empty email address.