### PR TITLE
[BACK-2329] Prevent updates to brokered users

### DIFF
--- a/user/api.go
+++ b/user/api.go
@@ -388,6 +388,9 @@ func (a *Api) UpdateUser(res http.ResponseWriter, req *http.Request, vars map[st
 	} else if originalUser == nil {
 		a.sendError(res, http.StatusUnauthorized, STATUS_UNAUTHORIZED, "User not found")
 
+	} else if originalUser.HasRole(RoleBrokered) {
+		a.sendError(res, http.StatusUnauthorized, STATUS_UNAUTHORIZED, "Updates to brokered users are not allowed")
+
 	} else if permissions, err := a.tokenUserHasRequestedPermissions(tokenData, originalUser.Id, clients.Permissions{"root": clients.Allowed, "custodian": clients.Allowed}); err != nil {
 		a.sendError(res, http.StatusInternalServerError, STATUS_ERR_FINDING_USR, err)
 
@@ -399,7 +402,6 @@ func (a *Api) UpdateUser(res http.ResponseWriter, req *http.Request, vars map[st
 
 	} else if (updateUserDetails.Password != nil || updateUserDetails.TermsAccepted != nil) && permissions["root"] == nil {
 		a.sendError(res, http.StatusUnauthorized, STATUS_UNAUTHORIZED, "User does not have permissions")
-
 	} else {
 		if updateUserDetails.Password != nil {
 			hash, err := GeneratePasswordHash(originalUser.Id, *updateUserDetails.Password, a.ApiConfig.Salt)

--- a/user/api_test.go
+++ b/user/api_test.go
@@ -1014,6 +1014,19 @@ func Test_UpdateUser_Error_UpdateUserError(t *testing.T) {
 	expectErrorResponse(t, response, 500, "Error updating user")
 }
 
+func Test_UpdateUser_Error_UpdateUserBrokeredError(t *testing.T) {
+	sessionToken := createSessionToken(t, "0000000000", false, tokenDuration)
+	responsableStore.FindTokenByIDResponses = []FindTokenByIDResponse{{sessionToken, nil}}
+	responsableStore.FindUserResponses = []FindUserResponse{{&User{Id: "1111111111", Roles: []string{RoleBrokered}}, nil}}
+	defer expectResponsablesEmpty(t)
+
+	body := "{\"updates\": {\"username\": \"a@z.co\", \"emails\": [\"a@z.co\"]}}"
+	headers := http.Header{}
+	headers.Add(TP_SESSION_TOKEN, sessionToken.ID)
+	response := performRequestBodyHeaders(t, "PUT", "/user/1111111111", body, headers)
+	expectErrorResponse(t, response, http.StatusUnauthorized, "Not authorized for requested operation")
+}
+
 func Test_UpdateUser_Error_RemoveCustodians_UsersInGroupError(t *testing.T) {
 	updatedUser := &User{
 		Id:            "1111111111",

--- a/user/user.go
+++ b/user/user.go
@@ -21,11 +21,13 @@ const (
 	RoleCustodialAccount = "custodial_account"
 	RoleMigratedClinic   = "migrated_clinic"
 	RolePatient          = "patient"
+	RoleBrokered         = "brokered"
 )
 
 var custodialAccountRegexp = regexp.MustCompile("unclaimed-custodial-automation\\+\\d+@tidepool\\.org")
 
 var validRoles = map[string]struct{}{
+	RoleBrokered:         {},
 	RoleClinic:           {},
 	RoleClinician:        {},
 	RoleCustodialAccount: {},


### PR DESCRIPTION
Brokered users should not be allowed to make any changes to their accounts, because their identities are managed externally 